### PR TITLE
Refactor: myApplicationStatus 경량 API로 분리

### DIFF
--- a/docs/API_명세서.md
+++ b/docs/API_명세서.md
@@ -459,14 +459,27 @@
   ],
   "members": [
     { "userId": 1, "nickname": "마감왕", "profileImage": "https://...", "role": "LEADER" }
-  ],
-  "myApplicationStatus": "PENDING"
+  ]
 }
 ```
 
 **비고**
 - 비로그인도 조회 가능
-- `myApplicationStatus`는 로그인 시에만 포함: `null` \| `PENDING` \| `ACCEPTED` \| `REJECTED`
+
+---
+
+### GET `/gatherings/{gatheringId}/application-status` 🔒
+> 모임 신청 상태 조회
+
+**Response `200`**
+```json
+{
+  "myApplicationStatus": "PENDING"
+}
+```
+
+**비고**
+- `myApplicationStatus`: `null` \| `PENDING` \| `ACCEPTED` \| `REJECTED`
 
 ---
 

--- a/docs/API_명세서.md
+++ b/docs/API_명세서.md
@@ -309,9 +309,9 @@
 **Query Parameters**
 
 | 파라미터 | 타입 | 기본값 | 설명 |
-|---|---|---|---|
+|------|----|---|----|
 | `type` | string | - | `스터디` \| `프로젝트` |
-| `category` | string | - | 개발/어학/독서/자격증 등 |
+| `categoryIds` | number[] | - | 개발/어학/독서/자격증 등 반복 파라미터 |
 | `sort` | string | `latest` | `latest` \| `popular` \| `deadline` |
 | `status` | string | `recruiting` | `recruiting` \| `all` |
 | `query` | string | - | 제목/소개/태그 검색어 |
@@ -325,7 +325,7 @@
     {
       "id": 1,
       "type": "스터디",
-      "category": "개발",
+      "categories": ["개발", "자격증"],
       "title": "React 완전 정복 스터디",
       "shortDescription": "리액트 공식문서를 같이 읽어요",
       "tags": ["React", "프론트엔드"],
@@ -347,6 +347,21 @@
 
 ---
 
+### GET `/gatherings/categories`
+> 카테고리 조회용
+
+**Response `200`**
+```json
+{
+  "categories": [
+    { "id": 1, "name": "개발" },
+    { "id": 2, "name": "어학" }
+  ]
+}
+```
+
+---
+
 ### POST `/gatherings` 🔒
 > 모임 생성
 
@@ -357,7 +372,7 @@
 ```json
 {
   "type": "스터디",
-  "category": "개발",
+  "categoryIds": [1, 2],
   "title": "React 완전 정복 스터디",
   "shortDescription": "리액트 공식문서를 같이 읽어요",
   "description": "매주 공식문서 1챕터씩 읽고 블로그를 작성합니다...",
@@ -421,7 +436,7 @@
 {
   "id": 1,
   "type": "스터디",
-  "category": "개발",
+  "categories": ["개발", "자격증"],
   "title": "React 완전 정복 스터디",
   "shortDescription": "리액트 공식문서를 같이 읽어요",
   "description": "...",
@@ -474,6 +489,9 @@
   "gathering": { "...": "수정된 모임 정보" }
 }
 ```
+
+**비고**
+- categoryIds: number[] (카테고리 수정 가능)
 
 ---
 
@@ -648,7 +666,7 @@
     {
       "id": 1,
       "type": "스터디",
-      "category": "개발",
+      "categories": ["개발", "자격증"],
       "title": "React 완전 정복 스터디",
       "shortDescription": "리액트 공식문서를 같이 읽어요",
       "tags": ["React", "프론트엔드"],
@@ -663,7 +681,7 @@
     {
       "id": 2,
       "type": "프로젝트",
-      "category": "개발",
+      "categories": ["개발", "자격증"],
       "title": "사이드 프로젝트 팀원 모집",
       "shortDescription": "Spring Boot 기반 협업 프로젝트",
       "tags": ["Spring", "백엔드"],
@@ -1143,7 +1161,7 @@
       {
         "id": 1,
         "type": "스터디",
-        "category": "개발",
+        "categories": ["개발", "자격증"],
         "title": "React 완전 정복",
         "shortDescription": "리액트 끝내기",
         "tags": ["React", "프론트엔드"],

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -23,6 +23,7 @@ gatherings ───────────────────────
   │  1:N  gathering_members (gathering_id)                                  │
   │  1:N  gathering_images (gathering_id)                                   │
   │  1:N  gathering_likes (gathering_id)                                    │
+  │  1:N  gathering_categories (gathering_id)                               │
   │  1:N  todos (gathering_id)                                              │
   │  1:N  notifications (gathering_id)                                      │
   │  1:N  reviews (gathering_id)                                            │
@@ -59,7 +60,6 @@ gatherings ───────────────────────
 | `id` | BIGINT | NOT NULL | PK | Auto Increment |
 | `leader_id` | BIGINT | NOT NULL | FK → users.id | 모임장 |
 | `type` | ENUM | NOT NULL | | `STUDY` \| `PROJECT` |
-| `category` | VARCHAR(50) | NOT NULL | | 개발/어학/독서/자격증 등 |
 | `title` | VARCHAR(60) | NOT NULL | | 모임 제목 (2~30자) |
 | `short_description` | VARCHAR(100) | NOT NULL | | 한 줄 소개 (2~50자) |
 | `description` | TEXT | NOT NULL | | 상세 설명 (10~1000자) |
@@ -98,6 +98,29 @@ gatherings ───────────────────────
 | `id` | BIGINT | NOT NULL | PK | Auto Increment |
 | `gathering_id` | BIGINT | NOT NULL | FK → gatherings.id | |
 | `tag` | VARCHAR(30) | NOT NULL | | 태그명 (최대 15자) |
+
+---
+
+### `categories` — 모임 카테고리
+
+| 컬럼명          | 타입          | NULL | KEY    | 설명              |
+|--------------|-------------|---|--------|-----------------|
+| `id`         | BIGINT      | NOT NULL | PK     | Auto Increment  |
+| `name`       | VARCHAR(50) | NOT NULL | UNIQUE | 카테고리명(개발, 어학 등) |
+| `created_at` | TIMESTAMP | NOT NULL | | 생성일시 |
+| `updated_at` | TIMESTAMP | NOT NULL | | 수정일시 |
+
+---
+
+### `gathering_categories` — 모임 카테고리 매핑
+
+| 컬럼명 | 타입 | NULL | KEY | 설명 |
+|------|----|---|-----|----|
+| `id` | BIGINT | NOT NULL | PK  | Auto Increment |
+| `gathering_id` | BIGINT | NOT NULL | FK → gatherings.id | |
+| `category_id` | BIGINT | NOT NULL | FK → categories.id | |
+| `created_at` | TIMESTAMP | NOT NULL | | 생성일시 |
+> **UNIQUE:** `(gathering_id, category_id) — 동일 모임에 동일 카테고리 중복 방지
 
 ---
 
@@ -265,10 +288,10 @@ gatherings ───────────────────────
 | `gatherings` | `(status, created_at)` | 목록 조회 / 최신순 정렬 |
 | `gatherings` | `recruit_deadline` | 마감임박 정렬 |
 | `gatherings` | `view_count` | 인기순 정렬 |
-| `gatherings` | `(type, category)` | 필터링 |
 | `applications` | `(gathering_id, applicant_id)` UNIQUE | 중복 신청 방지 |
 | `gathering_members` | `(gathering_id, user_id)` UNIQUE | 멤버 중복 방지 |
 | `gathering_members` | `(user_id, is_active)` | 내가 참여 중인 모임 조회 |
+| `gathering_categories` | `(category_id, gathering_id)` | 필터링 |
 | `gathering_images` | `(gathering_id, display_order)` | 모임별 이미지 조회 및 정렬 |
 | `gathering_likes` | `(user_id, created_at)` | 찜한 모임 목록 조회 |
 | `gathering_likes` | `(gathering_id, user_id)` UNIQUE | 중복 찜 방지/찜 여부 조회 |

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/response/GatheringDetailResponse.java
@@ -27,8 +27,7 @@ public record GatheringDetailResponse(
         boolean isLiked,
         LeaderResponse leader,
         List<WeeklyPlanResponse> weeklyPlans,
-        List<MemberResponse> members,
-        String myApplicationStatus
+        List<MemberResponse> members
 ) {
     @Builder
     public record ImageResponse(

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/response/MyApplicationStatusResponse.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/response/MyApplicationStatusResponse.java
@@ -1,0 +1,14 @@
+package com.fesi.deadlinemate.domain.gathering.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MyApplicationStatusResponse(
+        String myApplicationStatus
+) {
+    public static MyApplicationStatusResponse of(String myApplicationStatus) {
+        return MyApplicationStatusResponse.builder()
+                .myApplicationStatus(myApplicationStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryService.java
@@ -18,7 +18,6 @@ import com.fesi.deadlinemate.domain.user.client.UserClient;
 import com.fesi.deadlinemate.domain.user.client.dto.UserInfo;
 import com.fesi.deadlinemate.global.error.BusinessException;
 import com.fesi.deadlinemate.global.error.ErrorCode;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,7 +145,6 @@ public class GatheringQueryService {
                         .build())
                 .weeklyPlans(weeklyPlans)
                 .members(memberResponses)
-                .myApplicationStatus(null)
                 .build();
     }
 

--- a/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/controller/GatheringApplicationController.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/controller/GatheringApplicationController.java
@@ -1,5 +1,6 @@
 package com.fesi.deadlinemate.domain.gatheringApplication.controller;
 
+import com.fesi.deadlinemate.domain.gathering.dto.response.MyApplicationStatusResponse;
 import com.fesi.deadlinemate.domain.gatheringApplication.command.CreateApplicationCommand;
 import com.fesi.deadlinemate.domain.gatheringApplication.dto.request.CreateApplicationRequest;
 import com.fesi.deadlinemate.domain.gatheringApplication.dto.request.UpdateApplicationRequest;
@@ -80,7 +81,18 @@ public class GatheringApplicationController {
         return ApiResponse.success();
     }
 
-    @GetMapping("users/me/applications")
+    @GetMapping("/gatherings/{gatheringId}/application-status")
+    public ApiResponse<MyApplicationStatusResponse> getMyApplicationStatus(
+            @PathVariable Long gatheringId,
+            Authentication authentication
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ApiResponse.success(
+                gatheringApplicationService.getMyApplicationStatus(gatheringId, userId)
+        );
+    }
+
+    @GetMapping("/users/me/applications")
     public ApiResponse<MyApplicationListResponse> getMyApplications(Authentication authentication) {
         Long userId = (Long) authentication.getPrincipal();
         return ApiResponse.success(gatheringApplicationService.getMyApplications(userId));

--- a/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationService.java
@@ -1,5 +1,6 @@
 package com.fesi.deadlinemate.domain.gatheringApplication.service;
 
+import com.fesi.deadlinemate.domain.gathering.dto.response.MyApplicationStatusResponse;
 import com.fesi.deadlinemate.domain.gathering.entity.Gathering;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringRole;
@@ -187,6 +188,16 @@ public class GatheringApplicationService {
                 .toList();
 
         return MyApplicationListResponse.of(responses);
+    }
+
+    public MyApplicationStatusResponse getMyApplicationStatus(Long gatheringId, Long userId) {
+        GatheringApplication application = gatheringApplicationRepository
+                .findByGatheringIdAndApplicantId(gatheringId, userId)
+                .orElse(null);
+
+        return MyApplicationStatusResponse.of(
+                application == null ? null : application.getStatus().name()
+        );
     }
 
     private Gathering getGatheringForUpdate(UpdateApplicationCommand command) {


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #23 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [x] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> refactor/23/refactor-gathering -> main

### 📑 변경 사항
> GET /gatherings/:gatheringId는 성격상 공개 모임 정보 조회 API라서 로그인 사용자별 상태값이 섞이면 캐싱전략이 복잡해진다고 합니다. 프론트 요구사항 측, myApplicaitonStatus 분리하는 것이 깔끔하다고 판단이 들어 해당 부분 수정하였습니다.

### ✅ 코멘트
- category부분도 문서부분만 같이 수정해서 첨부하였습니다. API명세서, ERD 관련 부분 괜찮은지 한번만 확인 부탁드립니다. 감사합니다!