### PR TITLE
Feat/32/feat image upload service

### DIFF
--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/controller/GatheringController.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/controller/GatheringController.java
@@ -16,7 +16,9 @@ import com.fesi.deadlinemate.domain.gathering.service.GatheringService;
 import com.fesi.deadlinemate.domain.gathering.service.MembershipCommandService;
 import com.fesi.deadlinemate.domain.gathering.service.MembershipQueryService;
 import com.fesi.deadlinemate.global.common.ApiResponse;
+import com.fesi.deadlinemate.global.common.ImageStorageService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/gatherings")
@@ -41,16 +44,22 @@ public class GatheringController {
     private final GatheringQueryService gatheringQueryService;
     private final MembershipCommandService membershipCommandService;
     private final MembershipQueryService membershipQueryService;
+    private final ImageStorageService imageStorageService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<CreateGatheringResponse> create(
             @RequestPart("request") @Valid CreateGatheringRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
             Authentication authentication
     ) {
         Long userId = (Long) authentication.getPrincipal();
 
-        CreateGatheringCommand command = request.toCommand(userId);
+        List<String> imageUrls = (images != null && !images.isEmpty())
+                ? imageStorageService.uploadAll(images, "gatherings")
+                : List.of();
+
+        CreateGatheringCommand command = request.toCommand(userId, imageUrls);
         CreateGatheringResponse response = gatheringService.create(command);
 
         return ApiResponse.success(response);

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/request/CreateGatheringRequest.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/request/CreateGatheringRequest.java
@@ -62,7 +62,7 @@ public record CreateGatheringRequest(
         @NotEmpty(message = "주차별 계획은 최소 1개 이상 필요합니다.")
         List<WeeklyGuideRequest> weeklyGuides
 ) {
-    public CreateGatheringCommand toCommand(Long leaderId) {
+    public CreateGatheringCommand toCommand(Long leaderId, List<String> imageUrls) {
         return CreateGatheringCommand.builder()
                 .leaderId(leaderId)
                 .type(type)
@@ -85,7 +85,7 @@ public record CreateGatheringRequest(
                                 ))
                                 .toList()
                 )
-                .imageUrls(List.of())
+                .imageUrls(imageUrls)
                 .build();
     }
 

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringService.java
@@ -5,6 +5,7 @@ import com.fesi.deadlinemate.domain.gathering.command.UpdateGatheringCommand;
 import com.fesi.deadlinemate.domain.gathering.dto.response.CreateGatheringResponse;
 import com.fesi.deadlinemate.domain.gathering.dto.response.UpdateGatheringResponse;
 import com.fesi.deadlinemate.domain.gathering.entity.Gathering;
+import com.fesi.deadlinemate.domain.gathering.entity.GatheringImage;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringRole;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringStatus;
@@ -14,6 +15,7 @@ import com.fesi.deadlinemate.domain.gathering.event.GatheringCompletedEvent;
 import com.fesi.deadlinemate.domain.gathering.event.GatheringCreatedEvent;
 import com.fesi.deadlinemate.domain.gathering.event.GatheringDeletedEvent;
 import com.fesi.deadlinemate.domain.gathering.event.GatheringUpdatedEvent;
+import com.fesi.deadlinemate.domain.gathering.repository.GatheringImageRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringTagRepository;
@@ -41,6 +43,7 @@ public class GatheringService {
     private final GatheringTagRepository gatheringTagRepository;
     private final WeeklyPlanRepository weeklyPlanRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
+    private final GatheringImageRepository gatheringImageRepository;
     private final GatheringLikeRepository gatheringLikeRepository;
     private final UserClient userClient;
     private final ApplicationEventPublisher eventPublisher;
@@ -70,6 +73,7 @@ public class GatheringService {
         Gathering saved = gatheringRepository.save(gathering);
 
         saveTags(saved.getId(), command.tags());
+        saveImages(saved.getId(), command.imageUrls());
         saveWeeklyPlansFromCreate(
                 saved.getId(),
                 command.weeklyGuides(),
@@ -249,6 +253,23 @@ public class GatheringService {
     private int calculateTotalWeeks(LocalDate startDate, LocalDate endDate) {
         long days = ChronoUnit.DAYS.between(startDate, endDate);
         return (int) (days / 7) + 1;
+    }
+
+    private void saveImages(Long gatheringId, List<String> imageUrls) {
+        if (imageUrls == null || imageUrls.isEmpty()) {
+            return;
+        }
+
+        List<GatheringImage> entities = new java.util.ArrayList<>();
+        for (int i = 0; i < imageUrls.size(); i++) {
+            entities.add(GatheringImage.builder()
+                    .gatheringId(gatheringId)
+                    .imageUrl(imageUrls.get(i))
+                    .displayOrder(i)
+                    .build());
+        }
+
+        gatheringImageRepository.saveAll(entities);
     }
 
     private void saveTags(Long gatheringId, List<String> tags) {

--- a/src/main/java/com/fesi/deadlinemate/domain/user/controller/UserController.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.fesi.deadlinemate.domain.gathering.client.GatheringClient;
 import com.fesi.deadlinemate.domain.gathering.dto.response.MyGatheringListResponse;
 import com.fesi.deadlinemate.domain.user.dto.request.ChangePasswordRequest;
 import com.fesi.deadlinemate.domain.user.dto.request.UpdateProfileRequest;
+import com.fesi.deadlinemate.global.common.ImageStorageService;
 import com.fesi.deadlinemate.domain.user.dto.response.PublicProfileResponse;
 import com.fesi.deadlinemate.domain.user.dto.response.UserProfileResponse;
 import com.fesi.deadlinemate.domain.user.entity.User;
@@ -11,9 +12,11 @@ import com.fesi.deadlinemate.domain.user.service.UserService;
 import com.fesi.deadlinemate.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -22,6 +25,7 @@ public class UserController {
 
     private final UserService userService;
     private final GatheringClient gatheringClient;
+    private final ImageStorageService imageStorageService;
 
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserProfileResponse>> getMyProfile(Authentication authentication) {
@@ -30,12 +34,22 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(UserProfileResponse.from(user)));
     }
 
-    @PatchMapping("/me")
+    @PatchMapping(value = "/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<UserProfileResponse>> updateMyProfile(
             Authentication authentication,
-            @Valid @RequestBody UpdateProfileRequest request) {
+            @RequestPart(value = "request", required = false) @Valid UpdateProfileRequest request,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
         Long userId = (Long) authentication.getPrincipal();
-        User user = userService.updateProfile(userId, request.getNickname(), request.getProfileImage());
+
+        String imageUrl = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            imageUrl = imageStorageService.upload(profileImage, "profiles");
+        } else if (request != null) {
+            imageUrl = request.getProfileImage();
+        }
+
+        String nickname = (request != null) ? request.getNickname() : null;
+        User user = userService.updateProfile(userId, nickname, imageUrl);
         return ResponseEntity.ok(ApiResponse.success(UserProfileResponse.from(user)));
     }
 

--- a/src/main/java/com/fesi/deadlinemate/global/common/ImageStorageService.java
+++ b/src/main/java/com/fesi/deadlinemate/global/common/ImageStorageService.java
@@ -25,9 +25,6 @@ public class ImageStorageService {
     @Value("${image.upload-dir}")
     private String uploadDir;
 
-    @Value("${image.base-url}")
-    private String baseUrl;
-
     @PostConstruct
     public void init() {
         try {
@@ -51,7 +48,7 @@ public class ImageStorageService {
             throw new BusinessException(ErrorCode.IMAGE_UPLOAD_FAILED);
         }
 
-        return baseUrl + "/" + directory + "/" + filename;
+        return "/images/" + directory + "/" + filename;
     }
 
     public List<String> uploadAll(List<MultipartFile> files, String directory) {
@@ -60,12 +57,12 @@ public class ImageStorageService {
                 .toList();
     }
 
-    public void delete(String imageUrl) {
-        if (imageUrl == null || !imageUrl.startsWith(baseUrl)) {
+    public void delete(String imagePath) {
+        if (imagePath == null || !imagePath.startsWith("/images/")) {
             return;
         }
 
-        String relativePath = imageUrl.substring(baseUrl.length() + 1);
+        String relativePath = imagePath.substring("/images/".length());
         Path filePath = Paths.get(uploadDir, relativePath);
 
         try {

--- a/src/main/java/com/fesi/deadlinemate/global/common/ImageStorageService.java
+++ b/src/main/java/com/fesi/deadlinemate/global/common/ImageStorageService.java
@@ -1,0 +1,96 @@
+package com.fesi.deadlinemate.global.common;
+
+import com.fesi.deadlinemate.global.error.BusinessException;
+import com.fesi.deadlinemate.global.error.ErrorCode;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class ImageStorageService {
+
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/gif", "image/webp"
+    );
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+    @Value("${image.upload-dir}")
+    private String uploadDir;
+
+    @Value("${image.base-url}")
+    private String baseUrl;
+
+    @PostConstruct
+    public void init() {
+        try {
+            Files.createDirectories(Paths.get(uploadDir));
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 저장 디렉토리를 생성할 수 없습니다: " + uploadDir, e);
+        }
+    }
+
+    public String upload(MultipartFile file, String directory) {
+        validateFile(file);
+
+        String filename = UUID.randomUUID() + getExtension(file.getOriginalFilename());
+        Path dirPath = Paths.get(uploadDir, directory);
+        Path filePath = dirPath.resolve(filename);
+
+        try {
+            Files.createDirectories(dirPath);
+            file.transferTo(filePath.toFile());
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.IMAGE_UPLOAD_FAILED);
+        }
+
+        return baseUrl + "/" + directory + "/" + filename;
+    }
+
+    public List<String> uploadAll(List<MultipartFile> files, String directory) {
+        return files.stream()
+                .map(file -> upload(file, directory))
+                .toList();
+    }
+
+    public void delete(String imageUrl) {
+        if (imageUrl == null || !imageUrl.startsWith(baseUrl)) {
+            return;
+        }
+
+        String relativePath = imageUrl.substring(baseUrl.length() + 1);
+        Path filePath = Paths.get(uploadDir, relativePath);
+
+        try {
+            Files.deleteIfExists(filePath);
+        } catch (IOException e) {
+            // 파일 삭제 실패는 무시 (로그로 처리 가능)
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new BusinessException(ErrorCode.IMAGE_EMPTY);
+        }
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new BusinessException(ErrorCode.IMAGE_TOO_LARGE);
+        }
+        if (!ALLOWED_CONTENT_TYPES.contains(file.getContentType())) {
+            throw new BusinessException(ErrorCode.IMAGE_INVALID_TYPE);
+        }
+    }
+
+    private String getExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf("."));
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/global/config/SecurityConfig.java
+++ b/src/main/java/com/fesi/deadlinemate/global/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/gatherings").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/gatherings/main").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/gatherings/*").permitAll()
+                        .requestMatchers("/images/**").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/fesi/deadlinemate/global/config/WebConfig.java
+++ b/src/main/java/com/fesi/deadlinemate/global/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.fesi.deadlinemate.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${image.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:" + uploadDir + "/");
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/global/error/ErrorCode.java
+++ b/src/main/java/com/fesi/deadlinemate/global/error/ErrorCode.java
@@ -95,6 +95,12 @@ public enum ErrorCode {
     REVIEW_TARGET_NOT_A_MEMBER(HttpStatus.BAD_REQUEST, "리뷰 대상이 해당 모임의 멤버가 아닙니다."),
     INVALID_REVIEW_TAG(HttpStatus.BAD_REQUEST, "유효하지 않은 리뷰 태그입니다."),
 
+    // Image
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
+    IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다."),
+    IMAGE_TOO_LARGE(HttpStatus.BAD_REQUEST, "이미지 크기는 5MB 이하여야 합니다."),
+    IMAGE_INVALID_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않는 이미지 형식입니다. (JPEG, PNG, GIF, WebP만 가능)"),
+
     // Notification
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다.");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
       max-file-size: 5MB
       max-request-size: 20MB
 
+image:
+  upload-dir: ${IMAGE_UPLOAD_DIR:./data/images}
+
 server:
   port: 8080
 
@@ -40,10 +43,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-
-image:
-  upload-dir: ${IMAGE_UPLOAD_DIR:./data/images}
-  base-url: ${IMAGE_BASE_URL:http://localhost:8080/images}
 
 jwt:
   secret: local-dev-secret-key-that-is-at-least-256-bits-long-for-hs256
@@ -79,10 +78,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-
-image:
-  upload-dir: ${IMAGE_UPLOAD_DIR:/data/images}
-  base-url: ${IMAGE_BASE_URL}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,11 @@ spring:
   jackson:
     property-naming-strategy: LOWER_CAMEL_CASE
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 20MB
+
 server:
   port: 8080
 
@@ -35,6 +40,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+
+image:
+  upload-dir: ${IMAGE_UPLOAD_DIR:./data/images}
+  base-url: ${IMAGE_BASE_URL:http://localhost:8080/images}
 
 jwt:
   secret: local-dev-secret-key-that-is-at-least-256-bits-long-for-hs256
@@ -70,6 +79,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+image:
+  upload-dir: ${IMAGE_UPLOAD_DIR:/data/images}
+  base-url: ${IMAGE_BASE_URL}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/test/java/com/fesi/deadlinemate/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/user/controller/UserControllerTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -41,6 +42,12 @@ class UserControllerTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private com.fesi.deadlinemate.domain.gathering.client.GatheringClient gatheringClient;
+
+    @Mock
+    private com.fesi.deadlinemate.global.common.ImageStorageService imageStorageService;
 
     @BeforeEach
     void setUp() {
@@ -73,10 +80,14 @@ class UserControllerTest {
 
         UpdateProfileRequest request = new UpdateProfileRequest("새닉네임", null);
 
-        mockMvc.perform(patch("/api/v1/users/me")
-                        .principal(new UsernamePasswordAuthenticationToken(1L, null, List.of()))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request", "", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request));
+
+        mockMvc.perform(multipart("/api/v1/users/me")
+                        .file(requestPart)
+                        .with(req -> { req.setMethod("PATCH"); return req; })
+                        .principal(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));
     }

--- a/src/test/java/com/fesi/deadlinemate/global/common/ImageStorageServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/global/common/ImageStorageServiceTest.java
@@ -1,0 +1,187 @@
+package com.fesi.deadlinemate.global.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fesi.deadlinemate.global.error.BusinessException;
+import com.fesi.deadlinemate.global.error.ErrorCode;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.web.multipart.MultipartFile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+
+class ImageStorageServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    ImageStorageService imageStorageService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        imageStorageService = new ImageStorageService();
+        setField(imageStorageService, "uploadDir", tempDir.toString());
+        imageStorageService.init();
+    }
+
+    @Nested
+    @DisplayName("upload()")
+    class Upload {
+
+        @Test
+        @DisplayName("정상 이미지 업로드 시 /images/{directory}/{filename} 경로를 반환한다")
+        void upload_success() {
+            MockMultipartFile file = new MockMultipartFile(
+                    "image", "photo.jpg", "image/jpeg", new byte[100]);
+
+            String result = imageStorageService.upload(file, "gatherings");
+
+            assertThat(result).startsWith("/images/gatherings/");
+            assertThat(result).endsWith(".jpg");
+        }
+
+        @Test
+        @DisplayName("업로드된 파일이 실제로 디스크에 저장된다")
+        void upload_fileExistsOnDisk() {
+            MockMultipartFile file = new MockMultipartFile(
+                    "image", "photo.png", "image/png", new byte[100]);
+
+            String path = imageStorageService.upload(file, "users");
+
+            String filename = path.substring("/images/users/".length());
+            Path savedPath = tempDir.resolve("users").resolve(filename);
+            assertThat(Files.exists(savedPath)).isTrue();
+        }
+
+        @Test
+        @DisplayName("확장자가 없는 원본 파일명이어도 업로드가 된다")
+        void upload_noExtension() {
+            MockMultipartFile file = new MockMultipartFile(
+                    "image", "photo", "image/jpeg", new byte[100]);
+
+            String result = imageStorageService.upload(file, "gatherings");
+
+            assertThat(result).startsWith("/images/gatherings/");
+        }
+
+        @Test
+        @DisplayName("빈 파일 업로드 시 IMAGE_EMPTY 예외가 발생한다")
+        void upload_emptyFile() {
+            MockMultipartFile file = new MockMultipartFile(
+                    "image", "photo.jpg", "image/jpeg", new byte[0]);
+
+            assertThatThrownBy(() -> imageStorageService.upload(file, "gatherings"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(ErrorCode.IMAGE_EMPTY.getMessage());
+        }
+
+        @Test
+        @DisplayName("5MB 초과 파일 업로드 시 IMAGE_TOO_LARGE 예외가 발생한다")
+        void upload_tooLarge() {
+            byte[] largeContent = new byte[5 * 1024 * 1024 + 1];
+            MockMultipartFile file = new MockMultipartFile(
+                    "image", "big.jpg", "image/jpeg", largeContent);
+
+            assertThatThrownBy(() -> imageStorageService.upload(file, "gatherings"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(ErrorCode.IMAGE_TOO_LARGE.getMessage());
+        }
+
+        @Test
+        @DisplayName("허용되지 않는 Content-Type 업로드 시 IMAGE_INVALID_TYPE 예외가 발생한다")
+        void upload_invalidType() {
+            MockMultipartFile file = new MockMultipartFile(
+                    "image", "document.pdf", "application/pdf", new byte[100]);
+
+            assertThatThrownBy(() -> imageStorageService.upload(file, "gatherings"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(ErrorCode.IMAGE_INVALID_TYPE.getMessage());
+        }
+
+        @Test
+        @DisplayName("WebP 형식 파일은 정상적으로 업로드된다")
+        void upload_webp() {
+            MockMultipartFile file = new MockMultipartFile(
+                    "image", "photo.webp", "image/webp", new byte[100]);
+
+            String result = imageStorageService.upload(file, "gatherings");
+
+            assertThat(result).startsWith("/images/gatherings/");
+        }
+    }
+
+    @Nested
+    @DisplayName("uploadAll()")
+    class UploadAll {
+
+        @Test
+        @DisplayName("여러 파일을 한 번에 업로드하면 각각의 경로 목록을 반환한다")
+        void uploadAll_success() {
+            List<MultipartFile> files = List.of(
+                    new MockMultipartFile("f1", "a.jpg", "image/jpeg", new byte[100]),
+                    new MockMultipartFile("f2", "b.png", "image/png", new byte[100])
+            );
+
+            List<String> results = imageStorageService.uploadAll(files, "gatherings");
+
+            assertThat(results).hasSize(2);
+            assertThat(results).allMatch(p -> p.startsWith("/images/gatherings/"));
+        }
+    }
+
+    @Nested
+    @DisplayName("delete()")
+    class Delete {
+
+        @Test
+        @DisplayName("업로드한 파일을 경로로 삭제하면 디스크에서 제거된다")
+        void delete_success() throws IOException {
+            MockMultipartFile file = new MockMultipartFile(
+                    "image", "photo.jpg", "image/jpeg", new byte[100]);
+            String path = imageStorageService.upload(file, "gatherings");
+
+            imageStorageService.delete(path);
+
+            String filename = path.substring("/images/gatherings/".length());
+            Path savedPath = tempDir.resolve("gatherings").resolve(filename);
+            assertThat(Files.exists(savedPath)).isFalse();
+        }
+
+        @Test
+        @DisplayName("null 경로로 delete 호출 시 예외 없이 무시된다")
+        void delete_nullPath() {
+            assertThatCode(() -> imageStorageService.delete(null)).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("/images/ 로 시작하지 않는 경로는 무시된다")
+        void delete_externalUrl() {
+            assertThatCode(() ->
+                    imageStorageService.delete("https://cdn.example.com/photo.jpg"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 파일 경로로 delete 호출 시 예외 없이 무시된다")
+        void delete_notExists() {
+            assertThatCode(() ->
+                    imageStorageService.delete("/images/gatherings/nonexistent.jpg"))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,7 +14,6 @@ spring:
 
 image:
   upload-dir: ./build/test-images
-  base-url: http://localhost:8080/images
 
 jwt:
   secret: test-secret-key-that-is-at-least-256-bits-long-for-hs256-algorithm

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,6 +12,10 @@ spring:
       hibernate:
         format_sql: true
 
+image:
+  upload-dir: ./build/test-images
+  base-url: http://localhost:8080/images
+
 jwt:
   secret: test-secret-key-that-is-at-least-256-bits-long-for-hs256-algorithm
   access-expiration: 3600000


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #32 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/32/feat-image-upload-service -> dev

### 📑 변경 사항
 로컬 파일시스템 기반 이미지 업로드 서비스를 구현했습니다.                                   

  - ImageStorageService 추가 — 파일 크기(5MB), 형식(JPEG/PNG/GIF/WebP) 검증, UUID 기반 파일명 
  저장
  - 모임 생성(POST /gatherings) 시 이미지 multipart 업로드 연동, GatheringImage에 순서대로    
  저장
  - 유저 프로필 수정(PATCH /users/me) 시 프로필 이미지 업로드 연동
  - /images/** 정적 리소스 서빙 설정 추가
  - IMAGE_BASE_URL 환경변수 제거, 상대 경로(/images/...) 반환으로 단순화
  - image.upload-dir 글로벌 설정으로 이동, 기본값 ./data/images

### 🛠 테스트 결과

 upload() — 7건

  ┌─────────────────────────────────────────────────────────────────────────┬──────┐
  │                                 테스트                                  │ 결과 │
  ├─────────────────────────────────────────────────────────────────────────┼──────┤
  │ 정상 이미지 업로드 시 /images/{directory}/{filename} 경로를 반환한다    │ ✅   │
  ├─────────────────────────────────────────────────────────────────────────┼──────┤
  │ 업로드된 파일이 실제로 디스크에 저장된다                                │ ✅   │
  ├─────────────────────────────────────────────────────────────────────────┼──────┤
  │ 확장자가 없는 원본 파일명이어도 업로드가 된다                           │ ✅   │
  ├─────────────────────────────────────────────────────────────────────────┼──────┤
  │ WebP 형식 파일은 정상적으로 업로드된다                                  │ ✅   │
  ├─────────────────────────────────────────────────────────────────────────┼──────┤
  │ 빈 파일 업로드 시 IMAGE_EMPTY 예외가 발생한다                           │ ✅   │
  ├─────────────────────────────────────────────────────────────────────────┼──────┤
  │ 5MB 초과 파일 업로드 시 IMAGE_TOO_LARGE 예외가 발생한다                 │ ✅   │
  ├─────────────────────────────────────────────────────────────────────────┼──────┤
  │ 허용되지 않는 Content-Type 업로드 시 IMAGE_INVALID_TYPE 예외가 발생한다 │ ✅   │
  └─────────────────────────────────────────────────────────────────────────┴──────┘

  uploadAll() — 1건

  ┌────────────────────────────────────────────────────────────┬──────┐
  │                           테스트                           │ 결과 │
  ├────────────────────────────────────────────────────────────┼──────┤
  │ 여러 파일을 한 번에 업로드하면 각각의 경로 목록을 반환한다 │ ✅   │
  └────────────────────────────────────────────────────────────┴──────┘

  delete() — 4건

  ┌─────────────────────────────────────────────────────────────┬──────┐
  │                           테스트                            │ 결과 │
  ├─────────────────────────────────────────────────────────────┼──────┤
  │ 업로드한 파일을 경로로 삭제하면 디스크에서 제거된다         │ ✅   │
  ├─────────────────────────────────────────────────────────────┼──────┤
  │ null 경로로 delete 호출 시 예외 없이 무시된다               │ ✅   │
  ├─────────────────────────────────────────────────────────────┼──────┤
  │ /images/ 로 시작하지 않는 경로는 무시된다                   │ ✅   │
  ├─────────────────────────────────────────────────────────────┼──────┤
  │ 존재하지 않는 파일 경로로 delete 호출 시 예외 없이 무시된다 │ ✅   │
  └─────────────────────────────────────────────────────────────┴──────┘


### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.