### PR TITLE
Refactor: 주차별 세부사항 분리

### DIFF
--- a/docs/API_명세서.md
+++ b/docs/API_명세서.md
@@ -382,8 +382,14 @@
   "startDate": "2025-03-22",
   "endDate": "2025-04-19",
   "weeklyGuides": [
-    { "week": 1, "title": "JSX, 컴포넌트, Props", "content": "공식문서 1~3챕터 읽기" },
-    { "week": 2, "title": "State, 이벤트 처리", "content": "공식문서 4~6챕터 읽기" }
+    {
+      "week": 1,
+      "title": "피그마 이론",
+      "details": [
+        "01. 피그마 프레임 이론",
+        "02. 피그마 컴포넌트 마스터"
+      ]
+    }
   ]
 }
 ```
@@ -453,7 +459,16 @@
   "status": "RECRUITING",
   "leader": { "id": 1, "nickname": "마감왕", "profileImage": "https://..." },
   "weeklyPlans": [
-    { "week": 1, "title": "JSX, 컴포넌트, Props", "startDate": "2025-03-22", "endDate": "2025-03-28" }
+    {
+      "week": 1,
+      "title": "피그마 이론",
+      "startDate": "2025-03-15",
+      "endDate": "2025-03-21",
+      "details": [
+        "01. 피그마 프레임 이론",
+        "02. 피그마 컴포넌트 마스터"
+      ]
+    }
   ],
   "members": [
     { "userId": 1, "nickname": "마감왕", "profileImage": "https://...", "role": "LEADER" }

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -29,6 +29,10 @@ gatherings ───────────────────────
   │  1:N  reviews (gathering_id)                                            │
   │  1:1  gathering_reports (gathering_id)                                  │
   └───────────────────────────────────────────────────────────────────────┘
+  
+  weekly_plans ─────────────────────────────────────────────────────────────┐
+  │  1:N  weekly_plan_details (weekly_plan_id)
+  └───────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -132,10 +136,23 @@ gatherings ───────────────────────
 | `gathering_id` | BIGINT | NOT NULL | FK → gatherings.id | |
 | `week_number` | TINYINT | NOT NULL | | 주차 번호 (1~N) |
 | `title` | VARCHAR(100) | NULL | | 주차 제목 (선택) |
-| `content` | TEXT | NULL | | 주차 가이드 내용 (선택) |
 | `start_date` | DATE | NOT NULL | | 해당 주차 시작일 |
 | `end_date` | DATE | NOT NULL | | 해당 주차 종료일 |
 
+---
+
+### `weekly_plan_details` — 주차별 세부 계획
+
+| 컬럼명 | 타입 | NULL | KEY | 설명 |
+|---|---|---|---|---|
+| `id` | BIGINT | NOT NULL | PK | Auto Increment |
+| `weekly_plan_id` | BIGINT | NOT NULL | FK → weekly_plans.id | 소속 주차 계획 ID |
+| `display_order` | TINYINT | NOT NULL | | 세부 계획 순서 |
+| `content` | VARCHAR(200) | NOT NULL | | 세부 계획 내용 |
+| `created_at` | TIMESTAMP | NOT NULL | | 생성일시 |
+| `updated_at` | TIMESTAMP | NOT NULL | | 수정일시 |
+
+> **UNIQUE:** `(weekly_plan_id, display_order)` — 같은 주차 내 순서 중복 방지
 ---
 
 ### `applications` — 모임 신청
@@ -295,6 +312,7 @@ gatherings ───────────────────────
 | `gathering_images` | `(gathering_id, display_order)` | 모임별 이미지 조회 및 정렬 |
 | `gathering_likes` | `(user_id, created_at)` | 찜한 모임 목록 조회 |
 | `gathering_likes` | `(gathering_id, user_id)` UNIQUE | 중복 찜 방지/찜 여부 조회 |
+| `weekly_plan_details` | `(weekly_plan_id, display_order)` UNIQUE | 세부 계획 순서 보장 / 정렬 조회 |
 | `todos` | `(gathering_id, user_id, week_number)` | Todo 조회 |
 | `notifications` | `(user_id, is_read)` | 읽지 않은 알림 조회 |
 | `reviews` | `(gathering_id, reviewer_id, target_user_id)` UNIQUE | 중복 리뷰 방지 |

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/command/CreateGatheringCommand.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/command/CreateGatheringCommand.java
@@ -25,7 +25,7 @@ public record CreateGatheringCommand(
     public record CreateWeeklyGuideCommand(
             int week,
             String title,
-            String content
+            List<String> details
     ) {
     }
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/command/UpdateGatheringCommand.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/command/UpdateGatheringCommand.java
@@ -25,7 +25,7 @@ public record UpdateGatheringCommand(
     public record UpdateWeeklyGuideCommand(
             int week,
             String title,
-            String content
+            List<String> details
     ) {
     }
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/request/CreateGatheringRequest.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/request/CreateGatheringRequest.java
@@ -81,7 +81,7 @@ public record CreateGatheringRequest(
                                 .map(w -> new CreateGatheringCommand.CreateWeeklyGuideCommand(
                                         w.week(),
                                         w.title(),
-                                        w.content()
+                                        w.details() == null ? List.of() : w.details()
                                 ))
                                 .toList()
                 )
@@ -96,7 +96,9 @@ public record CreateGatheringRequest(
             @Size(max = 100, message = "주차 제목은 100자 이하여야 합니다.")
             String title,
 
-            String content
+            @Size(max = 2, message = "세부 계획은 최대 2개까지 입력할 수 있습니다.")
+            List<@NotBlank(message = "세부 계획은 비어 있을 수 없습니다.")
+            @Size(max = 200, message = "세부 계획은 200자 이하여야 합니다.") String> details
     ) {
     }
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/request/UpdateGatheringRequest.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/request/UpdateGatheringRequest.java
@@ -82,7 +82,7 @@ public record UpdateGatheringRequest(
                                 .map(w -> new UpdateGatheringCommand.UpdateWeeklyGuideCommand(
                                         w.week(),
                                         w.title(),
-                                        w.content()
+                                        w.details() == null ? List.of() : w.details()
                                 ))
                                 .toList()
                 )
@@ -97,7 +97,9 @@ public record UpdateGatheringRequest(
             @Size(max = 100, message = "주차 제목은 100자 이하여야 합니다.")
             String title,
 
-            String content
+            @Size(max = 2, message = "세부 계획은 최대 2개까지 입력할 수 있습니다.")
+            List<@NotBlank(message = "세부 계획은 비어 있을 수 없습니다.")
+            @Size(max = 200, message = "세부 계획은 200자 이하여야 합니다.") String> details
     ) {
     }
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/response/GatheringDetailResponse.java
@@ -48,7 +48,8 @@ public record GatheringDetailResponse(
             int week,
             String title,
             LocalDate startDate,
-            LocalDate endDate
+            LocalDate endDate,
+            List<String> details
     ) {
     }
 

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/WeeklyPlan.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/WeeklyPlan.java
@@ -33,9 +33,6 @@ public class WeeklyPlan extends BaseTimeEntity {
     @Column(length = 100)
     private String title;
 
-    @Lob
-    private String content;
-
     @Column(nullable = false)
     private LocalDate startDate;
 
@@ -43,12 +40,11 @@ public class WeeklyPlan extends BaseTimeEntity {
     private LocalDate endDate;
 
     @Builder
-    public WeeklyPlan(Long gatheringId, int weekNumber, String title, String content,
+    public WeeklyPlan(Long gatheringId, int weekNumber, String title,
                       LocalDate startDate, LocalDate endDate) {
         this.gatheringId = gatheringId;
         this.weekNumber = weekNumber;
         this.title = title;
-        this.content = content;
         this.startDate = startDate;
         this.endDate = endDate;
     }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/WeeklyPlanDetail.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/WeeklyPlanDetail.java
@@ -1,0 +1,51 @@
+package com.fesi.deadlinemate.domain.gathering.entity;
+
+import com.fesi.deadlinemate.global.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "weekly_plan_details",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_weekly_plan_details_order",
+                columnNames = {"weekly_plan_id", "display_order"}
+        ),
+        indexes = {
+                @Index(name = "idx_weekly_plan_details_plan_order", columnList = "weekly_plan_id, display_order")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WeeklyPlanDetail extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "weekly_plan_id", nullable = false)
+    private Long weeklyPlanId;
+
+    @Column(nullable = false)
+    private Integer displayOrder;
+
+    @Column(nullable = false, length = 200)
+    private String content;
+
+    @Builder
+    public WeeklyPlanDetail(Long weeklyPlanId, int displayOrder, String content) {
+        this.weeklyPlanId = weeklyPlanId;
+        this.displayOrder = displayOrder;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/repository/WeeklyPlanDetailRepository.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/repository/WeeklyPlanDetailRepository.java
@@ -1,0 +1,12 @@
+package com.fesi.deadlinemate.domain.gathering.repository;
+
+import com.fesi.deadlinemate.domain.gathering.entity.WeeklyPlanDetail;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeeklyPlanDetailRepository extends JpaRepository<WeeklyPlanDetail, Long> {
+
+    List<WeeklyPlanDetail> findByWeeklyPlanIdInOrderByWeeklyPlanIdAscDisplayOrderAsc(List<Long> weeklyPlanIds);
+
+    void deleteByWeeklyPlanIdIn(List<Long> weeklyPlanIds);
+}

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryService.java
@@ -9,6 +9,8 @@ import com.fesi.deadlinemate.domain.gathering.dto.response.GatheringListResponse
 import com.fesi.deadlinemate.domain.gathering.dto.response.GatheringMainResponse;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringTag;
+import com.fesi.deadlinemate.domain.gathering.entity.WeeklyPlan;
+import com.fesi.deadlinemate.domain.gathering.entity.WeeklyPlanDetail;
 import com.fesi.deadlinemate.domain.gathering.projection.GatheringDetailRow;
 import com.fesi.deadlinemate.domain.gathering.projection.GatheringListRow;
 import com.fesi.deadlinemate.domain.category.repository.CategoryRepository;
@@ -17,6 +19,7 @@ import com.fesi.deadlinemate.domain.gathering.repository.GatheringImageRepositor
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringTagRepository;
+import com.fesi.deadlinemate.domain.gathering.repository.WeeklyPlanDetailRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.WeeklyPlanRepository;
 import com.fesi.deadlinemate.domain.like.repository.GatheringLikeRepository;
 import com.fesi.deadlinemate.domain.user.client.UserClient;
@@ -46,6 +49,7 @@ public class GatheringQueryService {
     private final GatheringCategoryRepository gatheringCategoryRepository;
     private final CategoryRepository categoryRepository;
     private final WeeklyPlanRepository weeklyPlanRepository;
+    private final WeeklyPlanDetailRepository weeklyPlanDetailRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
     private final GatheringLikeRepository gatheringLikeRepository;
     private final UserClient userClient;
@@ -119,13 +123,28 @@ public class GatheringQueryService {
                         .build())
                 .toList();
 
-        List<GatheringDetailResponse.WeeklyPlanResponse> weeklyPlans = weeklyPlanRepository
-                .findByGatheringIdOrderByWeekNumberAsc(gatheringId).stream()
+        List<WeeklyPlan> weeklyPlans = weeklyPlanRepository.findByGatheringIdOrderByWeekNumberAsc(gatheringId);
+
+        List<Long> weeklyPlanIds = weeklyPlans.stream()
+                .map(WeeklyPlan::getId)
+                .toList();
+
+        Map<Long, List<String>> detailMap = weeklyPlanDetailRepository
+                .findByWeeklyPlanIdInOrderByWeeklyPlanIdAscDisplayOrderAsc(weeklyPlanIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        WeeklyPlanDetail::getWeeklyPlanId,
+                        LinkedHashMap::new,
+                        Collectors.mapping(WeeklyPlanDetail::getContent, Collectors.toList())
+                ));
+
+        List<GatheringDetailResponse.WeeklyPlanResponse> weeklyPlanResponses = weeklyPlans.stream()
                 .map(plan -> GatheringDetailResponse.WeeklyPlanResponse.builder()
                         .week(plan.getWeekNumber())
                         .title(plan.getTitle())
                         .startDate(plan.getStartDate())
                         .endDate(plan.getEndDate())
+                        .details(detailMap.getOrDefault(plan.getId(), List.of()))
                         .build())
                 .toList();
 
@@ -172,7 +191,7 @@ public class GatheringQueryService {
                         .nickname(leader.getNickname())
                         .profileImage(leader.getProfileImage())
                         .build())
-                .weeklyPlans(weeklyPlans)
+                .weeklyPlans(weeklyPlanResponses)
                 .members(memberResponses)
                 .build();
     }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringService.java
@@ -13,6 +13,7 @@ import com.fesi.deadlinemate.domain.gathering.entity.GatheringRole;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringStatus;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringTag;
 import com.fesi.deadlinemate.domain.gathering.entity.WeeklyPlan;
+import com.fesi.deadlinemate.domain.gathering.entity.WeeklyPlanDetail;
 import com.fesi.deadlinemate.domain.gathering.event.GatheringCompletedEvent;
 import com.fesi.deadlinemate.domain.gathering.event.GatheringCreatedEvent;
 import com.fesi.deadlinemate.domain.gathering.event.GatheringDeletedEvent;
@@ -23,6 +24,7 @@ import com.fesi.deadlinemate.domain.gathering.repository.GatheringImageRepositor
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringTagRepository;
+import com.fesi.deadlinemate.domain.gathering.repository.WeeklyPlanDetailRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.WeeklyPlanRepository;
 import com.fesi.deadlinemate.domain.like.repository.GatheringLikeRepository;
 import com.fesi.deadlinemate.domain.user.client.UserClient;
@@ -34,7 +36,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -50,6 +54,7 @@ public class GatheringService {
     private final GatheringCategoryRepository gatheringCategoryRepository;
     private final CategoryRepository categoryRepository;
     private final WeeklyPlanRepository weeklyPlanRepository;
+    private final WeeklyPlanDetailRepository weeklyPlanDetailRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
     private final GatheringImageRepository gatheringImageRepository;
     private final GatheringLikeRepository gatheringLikeRepository;
@@ -119,6 +124,7 @@ public class GatheringService {
         gathering.validateLeader(requesterId);
         gathering.validateDeletable();
 
+        deleteWeeklyPlanDetailsByGatheringId(gatheringId);
         weeklyPlanRepository.deleteByGatheringId(gatheringId);
         gatheringCategoryRepository.deleteByGatheringId(gatheringId);
         gatheringTagRepository.deleteByGatheringId(gatheringId);
@@ -148,6 +154,18 @@ public class GatheringService {
                     gathering.getTitle()
             ));
         }
+    }
+
+    private void deleteWeeklyPlanDetailsByGatheringId(Long gatheringId) {
+        List<Long> weeklyPlanIds = weeklyPlanRepository.findByGatheringIdOrderByWeekNumberAsc(gatheringId).stream()
+                .map(WeeklyPlan::getId)
+                .toList();
+
+        if (weeklyPlanIds.isEmpty()) {
+            return;
+        }
+
+        weeklyPlanDetailRepository.deleteByWeeklyPlanIdIn(weeklyPlanIds);
     }
 
     private UpdateGatheringResponse updateRecruitingGathering(Gathering gathering, UpdateGatheringCommand command) {
@@ -414,18 +432,45 @@ public class GatheringService {
             return;
         }
 
-        weeklyPlanRepository.saveAll(
-                weeklyGuides.stream()
-                        .map(guide -> buildWeeklyPlan(
-                                gatheringId,
-                                guide.week(),
-                                guide.title(),
-                                guide.content(),
-                                startDate,
-                                endDate
-                        ))
-                        .toList()
-        );
+        List<WeeklyPlan> weeklyPlans = weeklyGuides.stream()
+                .map(guide -> buildWeeklyPlan(
+                        gatheringId,
+                        guide.week(),
+                        guide.title(),
+                        startDate,
+                        endDate
+                ))
+                .toList();
+
+        List<WeeklyPlan> savedPlans = weeklyPlanRepository.saveAll(weeklyPlans);
+
+        saveWeeklyPlanDetailsFromCreate(savedPlans, weeklyGuides);
+    }
+
+    private void saveWeeklyPlanDetailsFromCreate(
+            List<WeeklyPlan> savedPlans,
+            List<CreateGatheringCommand.CreateWeeklyGuideCommand> weeklyGuides
+    ) {
+        Map<Integer, WeeklyPlan> weeklyPlanMap = savedPlans.stream()
+                .collect(Collectors.toMap(WeeklyPlan::getWeekNumber, Function.identity()));
+
+        List<WeeklyPlanDetail> details = weeklyGuides.stream()
+                .flatMap(guide -> {
+                    WeeklyPlan weeklyPlan = weeklyPlanMap.get(guide.week());
+                    List<String> items = normalizeDetails(guide.details());
+
+                    return IntStream.range(0, items.size())
+                            .mapToObj(i -> WeeklyPlanDetail.builder()
+                                    .weeklyPlanId(weeklyPlan.getId())
+                                    .displayOrder(i)
+                                    .content(items.get(i))
+                                    .build());
+                })
+                .toList();
+
+        if (!details.isEmpty()) {
+            weeklyPlanDetailRepository.saveAll(details);
+        }
     }
 
     private void replaceWeeklyPlansFromUpdate(
@@ -434,31 +479,82 @@ public class GatheringService {
             LocalDate startDate,
             LocalDate endDate
     ) {
+        List<WeeklyPlan> existingPlans = weeklyPlanRepository.findByGatheringIdOrderByWeekNumberAsc(gatheringId);
+        List<Long> existingPlanIds = existingPlans.stream()
+                .map(WeeklyPlan::getId)
+                .toList();
+
+        if (!existingPlanIds.isEmpty()) {
+            weeklyPlanDetailRepository.deleteByWeeklyPlanIdIn(existingPlanIds);
+        }
         weeklyPlanRepository.deleteByGatheringId(gatheringId);
 
         if (weeklyGuides == null || weeklyGuides.isEmpty()) {
             return;
         }
 
-        weeklyPlanRepository.saveAll(
-                weeklyGuides.stream()
-                        .map(guide -> buildWeeklyPlan(
-                                gatheringId,
-                                guide.week(),
-                                guide.title(),
-                                guide.content(),
-                                startDate,
-                                endDate
-                        ))
-                        .toList()
-        );
+        List<WeeklyPlan> weeklyPlans = weeklyGuides.stream()
+                .map(guide -> buildWeeklyPlan(
+                        gatheringId,
+                        guide.week(),
+                        guide.title(),
+                        startDate,
+                        endDate
+                ))
+                .toList();
+
+        List<WeeklyPlan> savedPlans = weeklyPlanRepository.saveAll(weeklyPlans);
+        saveWeeklyPlanDetailsFromUpdate(savedPlans, weeklyGuides);
+    }
+
+    private void saveWeeklyPlanDetailsFromUpdate(
+            List<WeeklyPlan> savedPlans,
+            List<UpdateGatheringCommand.UpdateWeeklyGuideCommand> weeklyGuides
+    ) {
+        Map<Integer, WeeklyPlan> weeklyPlanMap = savedPlans.stream()
+                .collect(Collectors.toMap(WeeklyPlan::getWeekNumber, Function.identity()));
+
+        List<WeeklyPlanDetail> details = weeklyGuides.stream()
+                .flatMap(guide -> {
+                    WeeklyPlan weeklyPlan = weeklyPlanMap.get(guide.week());
+                    List<String> items = normalizeDetails(guide.details());
+
+                    return IntStream.range(0, items.size())
+                            .mapToObj(i -> WeeklyPlanDetail.builder()
+                                    .weeklyPlanId(weeklyPlan.getId())
+                                    .displayOrder(i)
+                                    .content(items.get(i))
+                                    .build());
+                })
+                .toList();
+
+        if (!details.isEmpty()) {
+            weeklyPlanDetailRepository.saveAll(details);
+        }
+    }
+
+    private List<String> normalizeDetails(List<String> details) {
+        if (details == null || details.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> normalized = details.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList();
+
+        if (normalized.size() > 2) {
+            throw new BusinessException(ErrorCode.INVALID_WEEKLY_PLAN_DETAILS_COUNT);
+        }
+
+        return normalized;
     }
 
     private WeeklyPlan buildWeeklyPlan(
             Long gatheringId,
             int weekNumber,
             String title,
-            String content,
             LocalDate startDate,
             LocalDate endDate
     ) {
@@ -466,7 +562,6 @@ public class GatheringService {
                 .gatheringId(gatheringId)
                 .weekNumber(weekNumber)
                 .title(title)
-                .content(content)
                 .startDate(calculateWeekStartDate(startDate, weekNumber))
                 .endDate(calculateWeekEndDate(startDate, endDate, weekNumber))
                 .build();

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringService.java
@@ -243,12 +243,12 @@ public class GatheringService {
     private List<Category> validateAndLoadCategories(List<Long> categoryIds) {
         List<Long> normalizedIds = normalizeCategoryIds(categoryIds);
         if (normalizedIds.isEmpty()) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, "카테고리는 최소 1개 이상 필요합니다.");
+            throw new BusinessException(ErrorCode.GATHERING_CATEGORY_REQUIRED);
         }
 
         List<Category> categories = categoryRepository.findByIdIn(normalizedIds);
         if (categories.size() != normalizedIds.size()) {
-            throw new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 카테고리가 포함되어 있습니다.");
+            throw new BusinessException(ErrorCode.GATHERING_CATEGORY_NOT_FOUND);
         }
         return categories;
     }

--- a/src/main/java/com/fesi/deadlinemate/global/error/ErrorCode.java
+++ b/src/main/java/com/fesi/deadlinemate/global/error/ErrorCode.java
@@ -79,6 +79,7 @@ public enum ErrorCode {
 
     //WeeklyPlan
     INVALID_WEEKLY_GUIDE_SEQUENCE(HttpStatus.BAD_REQUEST,"주차 가이드는 1주차부터 순차적으로 입력되어야 합니다."),
+    INVALID_WEEKLY_PLAN_DETAILS_COUNT(HttpStatus.BAD_REQUEST, "세부 계획은 최대 2개까지 입력할 수 있습니다."),
 
     // Membership
     NOT_A_MEMBER(HttpStatus.FORBIDDEN, "모임 멤버만 접근할 수 있습니다."),

--- a/src/main/java/com/fesi/deadlinemate/global/error/ErrorCode.java
+++ b/src/main/java/com/fesi/deadlinemate/global/error/ErrorCode.java
@@ -42,7 +42,6 @@ public enum ErrorCode {
     GATHERING_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "진행 중인 모임은 삭제할 수 없습니다."),
     INVALID_MAX_MEMBERS(HttpStatus.BAD_REQUEST, "최대 인원은 2명 이상 10명 이하여야 합니다."),
     GATHERING_NOT_FOUND(HttpStatus.NOT_FOUND, "모임을 찾을 수 없습니다."),
-    GATHERING_CATEGORY_COUNT(HttpStatus.BAD_REQUEST, "카테고리는 최대 3개까지 선택할 수 있습니다."),
     GATHERING_COMPLETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "진행 중인 모임만 종료할 수 있습니다."),
 
     // GatheringApplication
@@ -76,6 +75,11 @@ public enum ErrorCode {
     GATHERING_REPORT_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "모임이 완료 상태가 아니므로 결과 리포트를 조회할 수 없습니다."),
     GATHERING_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "모임 결과 리포트를 찾을 수 없습니다."),
     INVALID_GATHERING_REPORT_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "모임 결과 리포트 데이터가 올바르지 않습니다."),
+
+    //CATEGORY
+    GATHERING_CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, "카테고리는 최소 1개 이상 필요합니다."),
+    GATHERING_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리가 포함되어 있습니다."),
+    GATHERING_CATEGORY_COUNT(HttpStatus.BAD_REQUEST, "카테고리는 최대 3개까지 선택할 수 있습니다."),
 
     //WeeklyPlan
     INVALID_WEEKLY_GUIDE_SEQUENCE(HttpStatus.BAD_REQUEST,"주차 가이드는 1주차부터 순차적으로 입력되어야 합니다."),

--- a/src/test/java/com/fesi/deadlinemate/domain/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/gathering/service/GatheringServiceTest.java
@@ -26,12 +26,16 @@ import com.fesi.deadlinemate.domain.gathering.entity.GatheringStatus;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringTag;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringType;
 import com.fesi.deadlinemate.domain.gathering.entity.WeeklyPlan;
+import com.fesi.deadlinemate.domain.gathering.entity.WeeklyPlanDetail;
 import com.fesi.deadlinemate.domain.gathering.event.GatheringCreatedEvent;
 import com.fesi.deadlinemate.domain.gathering.event.GatheringUpdatedEvent;
+import com.fesi.deadlinemate.domain.gathering.repository.GatheringImageRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringTagRepository;
+import com.fesi.deadlinemate.domain.gathering.repository.WeeklyPlanDetailRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.WeeklyPlanRepository;
+import com.fesi.deadlinemate.domain.like.repository.GatheringLikeRepository;
 import com.fesi.deadlinemate.domain.user.client.UserClient;
 import com.fesi.deadlinemate.global.error.BusinessException;
 import com.fesi.deadlinemate.global.error.ErrorCode;
@@ -63,6 +67,9 @@ class GatheringServiceTest {
     private WeeklyPlanRepository weeklyPlanRepository;
 
     @Mock
+    private WeeklyPlanDetailRepository weeklyPlanDetailRepository;
+
+    @Mock
     private GatheringMemberRepository gatheringMemberRepository;
 
     @Mock
@@ -70,6 +77,12 @@ class GatheringServiceTest {
 
     @Mock
     private GatheringCategoryRepository gatheringCategoryRepository;
+
+    @Mock
+    private GatheringImageRepository gatheringImageRepository;
+
+    @Mock
+    private GatheringLikeRepository gatheringLikeRepository;
 
     @Mock
     private UserClient userClient;
@@ -100,8 +113,12 @@ class GatheringServiceTest {
                 .startDate(LocalDate.of(2025, 3, 22))
                 .endDate(LocalDate.of(2025, 4, 19))
                 .weeklyGuides(List.of(
-                        new CreateGatheringCommand.CreateWeeklyGuideCommand(1, "JSX, 컴포넌트, Props", "공식문서 1~3챕터 읽기"),
-                        new CreateGatheringCommand.CreateWeeklyGuideCommand(2, "State, 이벤트 처리", "공식문서 4~6챕터 읽기")
+                        new CreateGatheringCommand.CreateWeeklyGuideCommand(
+                                1, "JSX, 컴포넌트, Props", List.of("공식문서 1~3챕터 읽기")
+                        ),
+                        new CreateGatheringCommand.CreateWeeklyGuideCommand(
+                                2, "State, 이벤트 처리", List.of("공식문서 4~6챕터 읽기")
+                        )
                 ))
                 .imageUrls(List.of())
                 .build();
@@ -120,8 +137,12 @@ class GatheringServiceTest {
                 .startDate(LocalDate.of(2025, 3, 27))
                 .endDate(LocalDate.of(2025, 5, 1))
                 .weeklyGuides(List.of(
-                        new UpdateGatheringCommand.UpdateWeeklyGuideCommand(1, "1주차", "기획 및 요구사항 정리"),
-                        new UpdateGatheringCommand.UpdateWeeklyGuideCommand(2, "2주차", "도메인 설계")
+                        new UpdateGatheringCommand.UpdateWeeklyGuideCommand(
+                                1, "1주차", List.of("기획 및 요구사항 정리")
+                        ),
+                        new UpdateGatheringCommand.UpdateWeeklyGuideCommand(
+                                2, "2주차", List.of("도메인 설계")
+                        )
                 ))
                 .imageUrls(List.of())
                 .build();
@@ -140,8 +161,12 @@ class GatheringServiceTest {
                 .endDate(LocalDate.of(2025, 4, 26))
                 .tags(List.of("React", "프론트엔드"))
                 .weeklyGuides(List.of(
-                        new UpdateGatheringCommand.UpdateWeeklyGuideCommand(1, "1주차 수정", "진행 중 계획 수정"),
-                        new UpdateGatheringCommand.UpdateWeeklyGuideCommand(2, "2주차 수정", "State 심화")
+                        new UpdateGatheringCommand.UpdateWeeklyGuideCommand(
+                                1, "1주차 수정", List.of("진행 중 계획 수정")
+                        ),
+                        new UpdateGatheringCommand.UpdateWeeklyGuideCommand(
+                                2, "2주차 수정", List.of("State 심화")
+                        )
                 ))
                 .imageUrls(List.of())
                 .build();
@@ -162,6 +187,18 @@ class GatheringServiceTest {
                         return gathering;
                     });
             given(gatheringMemberRepository.save(any(GatheringMember.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            given(weeklyPlanRepository.saveAll(anyList()))
+                    .willAnswer(invocation -> {
+                        List<WeeklyPlan> plans = invocation.getArgument(0);
+                        for (int i = 0; i < plans.size(); i++) {
+                            setField(plans.get(i), "id", (long) (i + 1));
+                        }
+                        return plans;
+                    });
+
+            given(weeklyPlanDetailRepository.saveAll(anyList()))
                     .willAnswer(invocation -> invocation.getArgument(0));
 
             // when
@@ -206,7 +243,6 @@ class GatheringServiceTest {
                             WeeklyPlan::getGatheringId,
                             WeeklyPlan::getWeekNumber,
                             WeeklyPlan::getTitle,
-                            WeeklyPlan::getContent,
                             WeeklyPlan::getStartDate,
                             WeeklyPlan::getEndDate
                     )
@@ -215,7 +251,6 @@ class GatheringServiceTest {
                                     100L,
                                     1,
                                     "JSX, 컴포넌트, Props",
-                                    "공식문서 1~3챕터 읽기",
                                     LocalDate.of(2025, 3, 22),
                                     LocalDate.of(2025, 3, 28)
                             ),
@@ -223,7 +258,6 @@ class GatheringServiceTest {
                                     100L,
                                     2,
                                     "State, 이벤트 처리",
-                                    "공식문서 4~6챕터 읽기",
                                     LocalDate.of(2025, 3, 29),
                                     LocalDate.of(2025, 4, 4)
                             )
@@ -244,6 +278,19 @@ class GatheringServiceTest {
             assertThat(leaderMember.getUserId()).isEqualTo(1L);
             assertThat(leaderMember.getRole()).isEqualTo(GatheringRole.LEADER);
             assertThat(leaderMember.isActive()).isTrue();
+
+            ArgumentCaptor<List<WeeklyPlanDetail>> detailCaptor = ArgumentCaptor.forClass(List.class);
+            then(weeklyPlanDetailRepository).should().saveAll(detailCaptor.capture());
+            assertThat(detailCaptor.getValue())
+                    .extracting(
+                            WeeklyPlanDetail::getWeeklyPlanId,
+                            WeeklyPlanDetail::getDisplayOrder,
+                            WeeklyPlanDetail::getContent
+                    )
+                    .containsExactly(
+                            tuple(1L, 0, "공식문서 1~3챕터 읽기"),
+                            tuple(2L, 0, "공식문서 4~6챕터 읽기")
+                    );
 
             ArgumentCaptor<GatheringCreatedEvent> eventCaptor = ArgumentCaptor.forClass(GatheringCreatedEvent.class);
             then(eventPublisher).should().publishEvent(eventCaptor.capture());
@@ -346,8 +393,8 @@ class GatheringServiceTest {
         void failWhenWeeklyGuideIsNotSequential() {
             CreateGatheringCommand command = createGatheringCommand.toBuilder()
                     .weeklyGuides(List.of(
-                            new CreateGatheringCommand.CreateWeeklyGuideCommand(1, "1주차", "내용"),
-                            new CreateGatheringCommand.CreateWeeklyGuideCommand(3, "3주차", "내용")
+                            new CreateGatheringCommand.CreateWeeklyGuideCommand(1, "1주차",List.of("내용")),
+                            new CreateGatheringCommand.CreateWeeklyGuideCommand(3, "3주차", List.of("내용"))
                     ))
                     .build();
 
@@ -377,13 +424,47 @@ class GatheringServiceTest {
             // given
             Gathering gathering = inProgressGathering();
             given(gatheringRepository.findById(100L)).willReturn(Optional.of(gathering));
+
             given(gatheringTagRepository.findByGatheringIdOrderByIdAsc(100L))
                     .willReturn(List.of(
                             GatheringTag.builder().gatheringId(100L).tag("React").build(),
                             GatheringTag.builder().gatheringId(100L).tag("프론트엔드").build()
                     ));
+
+            WeeklyPlan existingPlan1 = WeeklyPlan.builder()
+                    .gatheringId(100L)
+                    .weekNumber(1)
+                    .title("기존 1주차")
+                    .startDate(LocalDate.of(2025, 3, 22))
+                    .endDate(LocalDate.of(2025, 3, 28))
+                    .build();
+            setField(existingPlan1, "id", 11L);
+
+            WeeklyPlan existingPlan2 = WeeklyPlan.builder()
+                    .gatheringId(100L)
+                    .weekNumber(2)
+                    .title("기존 2주차")
+                    .startDate(LocalDate.of(2025, 3, 29))
+                    .endDate(LocalDate.of(2025, 4, 4))
+                    .build();
+            setField(existingPlan2, "id", 12L);
+
+            given(weeklyPlanRepository.findByGatheringIdOrderByWeekNumberAsc(100L))
+                    .willReturn(List.of(existingPlan1, existingPlan2));
+
+            given(weeklyPlanRepository.saveAll(anyList()))
+                    .willAnswer(invocation -> {
+                        List<WeeklyPlan> plans = invocation.getArgument(0);
+                        for (int i = 0; i < plans.size(); i++) {
+                            setField(plans.get(i), "id", (long) (101 + i));
+                        }
+                        return plans;
+                    });
+
+            given(weeklyPlanDetailRepository.saveAll(anyList()))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
             mockCurrentGatheringCategory(100L, 1L);
-            mockValidCategories();
 
             // when
             UpdateGatheringResponse response = gatheringService.update(100L, inProgressAllowedUpdateCommand);
@@ -402,11 +483,14 @@ class GatheringServiceTest {
             assertThat(gathering.getEndDate()).isEqualTo(LocalDate.of(2025, 4, 26));
             assertThat(gathering.getTotalWeeks()).isEqualTo(6);
 
-            then(weeklyPlanRepository).should().deleteByGatheringId(100L);
-            then(weeklyPlanRepository).should().saveAll(anyList());
             then(gatheringTagRepository).should(never()).deleteByGatheringId(anyLong());
             then(gatheringTagRepository).should(never()).saveAll(anyList());
             then(gatheringTagRepository).should().findByGatheringIdOrderByIdAsc(100L);
+
+            then(weeklyPlanDetailRepository).should().deleteByWeeklyPlanIdIn(List.of(11L, 12L));
+            then(weeklyPlanRepository).should().deleteByGatheringId(100L);
+            then(weeklyPlanRepository).should().saveAll(anyList());
+            then(weeklyPlanDetailRepository).should().saveAll(anyList());
 
             ArgumentCaptor<GatheringUpdatedEvent> eventCaptor =
                     ArgumentCaptor.forClass(GatheringUpdatedEvent.class);

--- a/src/test/java/com/fesi/deadlinemate/domain/review/controller/ReviewControllerE2ETest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/review/controller/ReviewControllerE2ETest.java
@@ -66,7 +66,7 @@ class ReviewControllerE2ETest {
 
         gathering = gatheringRepository.save(Gathering.builder()
                 .leaderId(reviewer.getId()).type(GatheringType.STUDY)
-                .category("개발").title("테스트 모임").shortDescription("설명")
+                .title("테스트 모임").shortDescription("설명")
                 .description("상세설명").goal("목표").maxMembers(10).currentMembers(2)
                 .recruitDeadline(LocalDate.now().minusDays(14))
                 .startDate(LocalDate.now().minusDays(7))

--- a/src/test/java/com/fesi/deadlinemate/domain/user/controller/UserGatheringsE2ETest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/user/controller/UserGatheringsE2ETest.java
@@ -67,7 +67,7 @@ class UserGatheringsE2ETest {
 
         gathering = gatheringRepository.save(Gathering.builder()
                 .leaderId(user.getId()).type(GatheringType.STUDY)
-                .category("개발").title("테스트 모임").shortDescription("설명")
+                .title("테스트 모임").shortDescription("설명")
                 .description("상세설명").goal("목표").maxMembers(10).currentMembers(2)
                 .recruitDeadline(LocalDate.now().minusDays(14))
                 .startDate(LocalDate.now().minusDays(7))
@@ -101,7 +101,7 @@ class UserGatheringsE2ETest {
     void sortOldest() throws Exception {
         Gathering gathering2 = gatheringRepository.save(Gathering.builder()
                 .leaderId(user.getId()).type(GatheringType.STUDY)
-                .category("개발").title("두번째 모임").shortDescription("설명")
+                .title("두번째 모임").shortDescription("설명")
                 .description("상세설명").goal("목표").maxMembers(10).currentMembers(1)
                 .recruitDeadline(LocalDate.now().minusDays(14))
                 .startDate(LocalDate.now().minusDays(7))
@@ -138,7 +138,7 @@ class UserGatheringsE2ETest {
     void pendingApplicationCountNullForMember() throws Exception {
         Gathering otherGathering = gatheringRepository.save(Gathering.builder()
                 .leaderId(applicant.getId()).type(GatheringType.STUDY)
-                .category("개발").title("남의 모임").shortDescription("설명")
+                .title("남의 모임").shortDescription("설명")
                 .description("상세설명").goal("목표").maxMembers(10).currentMembers(2)
                 .recruitDeadline(LocalDate.now().minusDays(14))
                 .startDate(LocalDate.now().minusDays(7))


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #37 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [x] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> refactor/37/gathering-detail-weekplans -> dev

### 📑 변경 사항
> 주차별 세부사항을 최대 2개 저장하도록 수정하였습니다.
<img width="612" height="457" alt="Screenshot 2026-04-07 at 7 14 23 PM" src="https://github.com/user-attachments/assets/6ca2f8c2-9c7b-4c45-8a31-65b7f48ee552" />

### 🛠 테스트 결과
mockBean, category 제외 테스트 통과

### ✅ 코멘트
요청 사항 문서 확인할때 API만 확인했더니 주차별을 제가 수정해버렸네요..ㅎ (죄송합니다😂 다음부터 내용까지 확인하겠습니다!)
테스트 돌려보는데 mockBean이 있더라고요.저는 'org.springframework.boot.test.mock.mockito.MockBean' is deprecated since version 3.4.0 and marked for removal 해당 오류가 떠서 일단 주석 처리하고 테스트 돌려보긴 했습니다! 