### PR TITLE
Refactor:달성률 및 모임 신청 수정

### DIFF
--- a/src/main/java/com/fesi/deadlinemate/domain/achievement/controller/AchievementController.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/achievement/controller/AchievementController.java
@@ -2,7 +2,7 @@ package com.fesi.deadlinemate.domain.achievement.controller;
 
 import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementRankingResponse;
 import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementResponse;
-import com.fesi.deadlinemate.domain.achievement.service.AchievementQueryService;
+import com.fesi.deadlinemate.domain.achievement.service.AchievementService;
 import com.fesi.deadlinemate.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AchievementController {
 
-    private final AchievementQueryService achievementQueryService;
+    private final AchievementService achievementService;
 
     @GetMapping("/{gatheringId}/achievements")
     public ApiResponse<AchievementResponse> getAchievements(
@@ -25,7 +25,7 @@ public class AchievementController {
     ) {
         Long userId = (Long) authentication.getPrincipal();
         return ApiResponse.success(
-                achievementQueryService.getAchievements(gatheringId, userId)
+                achievementService.getAchievements(gatheringId, userId)
         );
     }
 
@@ -36,7 +36,7 @@ public class AchievementController {
     ) {
         Long userId = (Long) authentication.getPrincipal();
         return ApiResponse.success(
-                achievementQueryService.getRanking(gatheringId, userId)
+                achievementService.getRanking(gatheringId, userId)
         );
     }
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementService.java
@@ -16,7 +16,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class AchievementQueryService {
+public class AchievementService {
 
     private final GatheringRepository gatheringRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
@@ -57,17 +57,20 @@ public class AchievementQueryService {
                         .toList()
         );
 
+        Map<Long, List<Todo>> todosByUser = groupByUser(todos);
+        Map<Integer, List<Todo>> teamTodosByWeek = groupByWeek(todos);
+        Map<Long, Map<Integer, List<Todo>>> todosByUserAndWeek = groupByUserAndWeek(todos);
+
         List<AchievementResponse.MemberAchievementResponse> memberResponses = activeMembers.stream()
                 .map(member -> {
                     Long userId = member.getUserId();
                     UserInfo user = userMap.get(userId);
 
-                    List<Todo> memberTodos = todos.stream()
-                            .filter(todo -> todo.getUserId().equals(userId))
-                            .toList();
+                    List<Todo> memberTodos = todosByUser.getOrDefault(userId, List.of());
+                    Map<Integer, List<Todo>> memberWeekMap = todosByUserAndWeek.getOrDefault(userId, Map.of());
 
                     List<AchievementResponse.WeeklyRateResponse> weeklyRates =
-                            buildWeeklyRates(memberTodos, gathering.getTotalWeeks());
+                            buildWeeklyRates(memberWeekMap, gathering.getTotalWeeks());
 
                     BigDecimal overallRate = calculateOverallRate(memberTodos);
 
@@ -81,7 +84,7 @@ public class AchievementQueryService {
                 .toList();
 
         List<AchievementResponse.WeeklyRateResponse> teamWeeklyRates =
-                buildWeeklyRates(todos, gathering.getTotalWeeks());
+                buildWeeklyRates(teamTodosByWeek, gathering.getTotalWeeks());
 
         BigDecimal teamOverallRate = calculateOverallRate(todos);
 
@@ -114,17 +117,13 @@ public class AchievementQueryService {
                         .toList()
         );
 
-        List<MemberRateRow> memberRates = activeMembers.stream()
-                .map(member -> {
-                    List<Todo> memberTodos = todos.stream()
-                            .filter(todo -> todo.getUserId().equals(member.getUserId()))
-                            .toList();
+        Map<Long, List<Todo>> todosByUser = groupByUser(todos);
 
-                    return new MemberRateRow(
-                            member.getUserId(),
-                            calculateOverallRate(memberTodos)
-                    );
-                })
+        List<MemberRateRow> memberRates = activeMembers.stream()
+                .map(member -> new MemberRateRow(
+                        member.getUserId(),
+                        calculateOverallRate(todosByUser.getOrDefault(member.getUserId(), List.of()))
+                ))
                 .sorted(Comparator
                         .comparing(MemberRateRow::overallRate, Comparator.reverseOrder())
                         .thenComparing(MemberRateRow::userId))
@@ -147,6 +146,56 @@ public class AchievementQueryService {
         return AchievementRankingResponse.of(ranking);
     }
 
+    @Transactional
+    public void sync(Long gatheringId, Long userId) {
+        GatheringMember member = gatheringMemberRepository
+                .findByGatheringIdAndUserIdAndIsActiveTrue(gatheringId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        long totalCount = todoRepository.countByGatheringIdAndUserId(gatheringId, userId);
+        long completedCount = todoRepository.countByGatheringIdAndUserIdAndIsCompletedTrue(gatheringId, userId);
+
+        BigDecimal rate = totalCount == 0
+                ? BigDecimal.ZERO
+                : BigDecimal.valueOf(completedCount)
+                        .multiply(BigDecimal.valueOf(100))
+                        .divide(BigDecimal.valueOf(totalCount), 1, RoundingMode.HALF_UP);
+
+        member.updateOverallAchievementRate(rate);
+    }
+
+    private Map<Long, List<Todo>> groupByUser(List<Todo> todos) {
+        return todos.stream()
+                .collect(Collectors.groupingBy(
+                        Todo::getUserId,
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+    }
+
+    private Map<Integer, List<Todo>> groupByWeek(List<Todo> todos) {
+        return todos.stream()
+                .collect(Collectors.groupingBy(
+                        Todo::getWeekNumber,
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+    }
+
+    private Map<Long, Map<Integer, List<Todo>>> groupByUserAndWeek(List<Todo> todos) {
+        return todos.stream()
+                .collect(Collectors.groupingBy(
+                        Todo::getUserId,
+                        LinkedHashMap::new,
+                        Collectors.groupingBy(
+                                Todo::getWeekNumber,
+                                LinkedHashMap::new,
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+
     private Gathering findGathering(Long gatheringId) {
         return gatheringRepository.findById(gatheringId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GATHERING_NOT_FOUND));
@@ -161,15 +210,14 @@ public class AchievementQueryService {
         }
     }
 
-    private List<AchievementResponse.WeeklyRateResponse> buildWeeklyRates(List<Todo> todos, int totalWeeks) {
+    private List<AchievementResponse.WeeklyRateResponse> buildWeeklyRates(
+            Map<Integer, List<Todo>> todosByWeek,
+            int totalWeeks
+    ) {
         List<AchievementResponse.WeeklyRateResponse> result = new ArrayList<>();
 
         for (int week = 1; week <= totalWeeks; week++) {
-            final int targetWeek = week;
-
-            List<Todo> weeklyTodos = todos.stream()
-                    .filter(todo -> todo.getWeekNumber() == targetWeek)
-                    .toList();
+            List<Todo> weeklyTodos = todosByWeek.getOrDefault(week, List.of());
 
             result.add(AchievementResponse.WeeklyRateResponse.builder()
                     .week(week)

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/GatheringMember.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/GatheringMember.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -63,5 +64,13 @@ public class GatheringMember {
 
     public void deactivate() {
         this.isActive = false;
+    }
+
+    public void updateOverallAchievementRate(BigDecimal overallAchievementRate) {
+        if (overallAchievementRate == null) {
+            this.overallAchievementRate = BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
+            return;
+        }
+        this.overallAchievementRate = overallAchievementRate.setScale(1, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationService.java
@@ -27,6 +27,7 @@ import com.fesi.deadlinemate.global.error.ErrorCode;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -184,7 +185,7 @@ public class GatheringApplicationService {
                     Gathering gathering = gatheringMap.get(application.getGatheringId());
 
                     if (gathering == null) {
-                        throw new BusinessException(ErrorCode.GATHERING_NOT_FOUND);
+                        return null;
                     }
 
                     return MyApplicationListResponse.MyApplicationItemResponse.builder()
@@ -200,6 +201,7 @@ public class GatheringApplicationService {
                             .createdAt(application.getCreatedAt())
                             .build();
                 })
+                .filter(Objects::nonNull)
                 .toList();
 
         return MyApplicationListResponse.of(responses);

--- a/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
@@ -19,6 +19,7 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,14 +66,23 @@ public class GatheringReportService {
                 .filter(todo -> userIdSet.contains(todo.getUserId()))
                 .toList();
 
-        List<WeeklyRateDto> teamWeeklyRates = buildTeamWeeklyRates(todos, gathering.getTotalWeeks());
+        Map<Long, List<Todo>> todosByUser = groupByUser(todos);
+        Map<Integer, List<Todo>> teamTodosByWeek = groupByWeek(todos);
+        Map<Long, Map<Integer, List<Todo>>> todosByUserAndWeek = groupByUserAndWeek(todos);
+
+        List<WeeklyRateDto> teamWeeklyRates = buildWeeklyRates(teamTodosByWeek, gathering.getTotalWeeks());
         BigDecimal teamOverallRate = calculateRate(
                 todos.stream().filter(Todo::isCompleted).count(),
                 todos.size()
         );
 
         List<MemberReportRow> memberRows = activeMembers.stream()
-                .map(member -> buildMemberReportRow(member.getUserId(), gathering.getTotalWeeks(), todos))
+                .map(member -> buildMemberReportRow(
+                        member.getUserId(),
+                        gathering.getTotalWeeks(),
+                        todosByUser.getOrDefault(member.getUserId(), List.of()),
+                        todosByUserAndWeek.getOrDefault(member.getUserId(), Map.of())
+                ))
                 .toList();
 
         Long mvpUserId = memberRows.stream()
@@ -107,7 +117,7 @@ public class GatheringReportService {
 
         GatheringReport report = GatheringReport.builder()
                 .gatheringId(gatheringId)
-                .teamOverallRate(teamOverallRate.setScale(2, RoundingMode.HALF_UP))
+                .teamOverallRate(teamOverallRate.setScale(1, RoundingMode.HALF_UP))
                 .mvpUserId(mvpUserId)
                 .longestStreakUserId(longestStreakUserId)
                 .mostImprovedUserId(mostImprovedUserId)
@@ -118,15 +128,42 @@ public class GatheringReportService {
         gatheringReportRepository.save(report);
     }
 
-    private List<WeeklyRateDto> buildTeamWeeklyRates(List<Todo> todos, int totalWeeks) {
+    private Map<Long, List<Todo>> groupByUser(List<Todo> todos) {
+        return todos.stream()
+                .collect(Collectors.groupingBy(
+                        Todo::getUserId,
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+    }
+
+    private Map<Integer, List<Todo>> groupByWeek(List<Todo> todos) {
+        return todos.stream()
+                .collect(Collectors.groupingBy(
+                        Todo::getWeekNumber,
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+    }
+
+    private Map<Long, Map<Integer, List<Todo>>> groupByUserAndWeek(List<Todo> todos) {
+        return todos.stream()
+                .collect(Collectors.groupingBy(
+                        Todo::getUserId,
+                        LinkedHashMap::new,
+                        Collectors.groupingBy(
+                                Todo::getWeekNumber,
+                                LinkedHashMap::new,
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+    private List<WeeklyRateDto> buildWeeklyRates(Map<Integer, List<Todo>> todosByWeek, int totalWeeks) {
         List<WeeklyRateDto> result = new ArrayList<>();
 
         for (int week = 1; week <= totalWeeks; week++) {
-            final int targetWeek = week;
-
-            List<Todo> weeklyTodos = todos.stream()
-                    .filter(todo -> todo.getWeekNumber() == targetWeek)
-                    .toList();
+            List<Todo> weeklyTodos = todosByWeek.getOrDefault(week, List.of());
 
             long totalCount = weeklyTodos.size();
             long completedCount = weeklyTodos.stream()
@@ -142,11 +179,12 @@ public class GatheringReportService {
         return result;
     }
 
-    private MemberReportRow buildMemberReportRow(Long userId, int totalWeeks, List<Todo> allTodos) {
-        List<Todo> memberTodos = allTodos.stream()
-                .filter(todo -> todo.getUserId().equals(userId))
-                .toList();
-
+    private MemberReportRow buildMemberReportRow(
+            Long userId,
+            int totalWeeks,
+            List<Todo> memberTodos,
+            Map<Integer, List<Todo>> memberTodosByWeek
+    ) {
         long totalTodos = memberTodos.size();
         long completedTodos = memberTodos.stream()
                 .filter(Todo::isCompleted)
@@ -156,11 +194,7 @@ public class GatheringReportService {
 
         List<BigDecimal> weeklyRates = new ArrayList<>();
         for (int week = 1; week <= totalWeeks; week++) {
-            final int targetWeek = week;
-
-            List<Todo> weeklyTodos = memberTodos.stream()
-                    .filter(todo -> todo.getWeekNumber() == targetWeek)
-                    .toList();
+            List<Todo> weeklyTodos = memberTodosByWeek.getOrDefault(week, List.of());
 
             long weekTotal = weeklyTodos.size();
             long weekCompleted = weeklyTodos.stream()
@@ -172,7 +206,7 @@ public class GatheringReportService {
 
         int longestStreak = calculateLongestPerfectStreak(weeklyRates);
         BigDecimal improvement = calculateImprovement(weeklyRates);
-        boolean attendanceAwardWinner = isAttendanceAwardWinner(memberTodos, totalWeeks);
+        boolean attendanceAwardWinner = isAttendanceAwardWinner(memberTodosByWeek, totalWeeks);
 
         return new MemberReportRow(
                 userId,
@@ -220,16 +254,15 @@ public class GatheringReportService {
         return lastWeek.subtract(firstWeek).setScale(1, RoundingMode.HALF_UP);
     }
 
-    private boolean isAttendanceAwardWinner(List<Todo> memberTodos, int totalWeeks) {
-        Map<Integer, Long> completedCountByWeek = memberTodos.stream()
-                .filter(Todo::isCompleted)
-                .collect(Collectors.groupingBy(
-                        Todo::getWeekNumber,
-                        Collectors.counting()
-                ));
-
+    private boolean isAttendanceAwardWinner(Map<Integer, List<Todo>> memberTodosByWeek, int totalWeeks) {
         for (int week = 1; week <= totalWeeks; week++) {
-            if (completedCountByWeek.getOrDefault(week, 0L) < 1L) {
+            List<Todo> weeklyTodos = memberTodosByWeek.getOrDefault(week, List.of());
+
+            long completedCount = weeklyTodos.stream()
+                    .filter(Todo::isCompleted)
+                    .count();
+
+            if (completedCount < 1L) {
                 return false;
             }
         }

--- a/src/main/java/com/fesi/deadlinemate/domain/todo/service/TodoService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/todo/service/TodoService.java
@@ -1,6 +1,8 @@
 package com.fesi.deadlinemate.domain.todo.service;
 
+import com.fesi.deadlinemate.domain.achievement.service.AchievementService;
 import com.fesi.deadlinemate.domain.gathering.entity.Gathering;
+import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
 import com.fesi.deadlinemate.domain.todo.command.CreateTodoCommand;
@@ -24,6 +26,8 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -37,6 +41,7 @@ public class TodoService {
     private final TodoRepository todoRepository;
     private final GatheringRepository gatheringRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
+    private final AchievementService achievementService;
     private final UserClient userClient;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -57,6 +62,8 @@ public class TodoService {
                 .build();
 
         Todo saved = todoRepository.save(todo);
+
+        achievementService.sync(saved.getGatheringId(), saved.getUserId());
 
         eventPublisher.publishEvent(new TodoCreatedEvent(
                 saved.getId(),
@@ -97,6 +104,8 @@ public class TodoService {
             throw new BusinessException(ErrorCode.TODO_NOT_CHANGED);
         }
 
+        achievementService.sync(todo.getGatheringId(), todo.getUserId());
+
         eventPublisher.publishEvent(new TodoUpdatedEvent(
                 todo.getId(),
                 todo.getGatheringId(),
@@ -119,7 +128,12 @@ public class TodoService {
         todo.validateDeletableBy(requesterId);
         validateCurrentWeek(gathering, todo.getWeekNumber());
 
+        Long ownerId = todo.getUserId();
+
         todoRepository.delete(todo);
+        todoRepository.flush();
+
+        achievementService.sync(gatheringId, ownerId);
 
         eventPublisher.publishEvent(new TodoDeletedEvent(
                 todo.getId(),
@@ -136,6 +150,16 @@ public class TodoService {
         List<Todo> todos = (week == null)
                 ? todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId)
                 : todoRepository.findByGatheringIdAndWeekNumberOrderByCreatedAtAsc(gatheringId, week);
+
+        Set<Long> activeUserIds = gatheringMemberRepository
+                .findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId)
+                .stream()
+                .map(GatheringMember::getUserId)
+                .collect(Collectors.toSet());
+
+        todos = todos.stream()
+                .filter(todo -> activeUserIds.contains(todo.getUserId()))
+                .toList();
 
         Map<Long, UserInfo> userMap = loadUsers(
                 todos.stream()

--- a/src/test/java/com/fesi/deadlinemate/domain/achievement/controller/AchievementControllerTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/achievement/controller/AchievementControllerTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementRankingResponse;
 import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementResponse;
-import com.fesi.deadlinemate.domain.achievement.service.AchievementQueryService;
+import com.fesi.deadlinemate.domain.achievement.service.AchievementService;
 import com.fesi.deadlinemate.global.security.JwtTokenProvider;
 import java.math.BigDecimal;
 import java.util.List;
@@ -37,7 +37,7 @@ class AchievementControllerTest {
     private JwtTokenProvider jwtTokenProvider;
 
     @MockitoBean
-    private AchievementQueryService achievementQueryService;
+    private AchievementService achievementService;
 
     private String token;
     private AchievementResponse achievementResponse;
@@ -57,7 +57,7 @@ class AchievementControllerTest {
         @Test
         @DisplayName("인증된 사용자는 모임 전체 달성률 현황을 조회할 수 있다")
         void getAchievements_success() throws Exception {
-            given(achievementQueryService.getAchievements(1L, 1L))
+            given(achievementService.getAchievements(1L, 1L))
                     .willReturn(achievementResponse);
 
             mockMvc.perform(get("/api/v1/gatherings/{gatheringId}/achievements", 1L)
@@ -85,7 +85,7 @@ class AchievementControllerTest {
         @Test
         @DisplayName("인증된 사용자는 달성률 순위를 조회할 수 있다")
         void getRanking_success() throws Exception {
-            given(achievementQueryService.getRanking(1L, 1L))
+            given(achievementService.getRanking(1L, 1L))
                     .willReturn(rankingResponse);
 
             mockMvc.perform(get("/api/v1/gatherings/{gatheringId}/achievements/ranking", 1L)

--- a/src/test/java/com/fesi/deadlinemate/domain/achievement/service/AchievementServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/achievement/service/AchievementServiceTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class AchievementQueryServiceTest {
+class AchievementServiceTest {
 
     @Mock
     private GatheringRepository gatheringRepository;
@@ -42,7 +42,7 @@ class AchievementQueryServiceTest {
     private UserClient userClient;
 
     @InjectMocks
-    private AchievementQueryService achievementQueryService;
+    private AchievementService achievementService;
 
     private final Long GATHERING_ID = 1L;
     private final Long USER_ID_1 = 10L;
@@ -95,7 +95,7 @@ class AchievementQueryServiceTest {
 
         // when
         AchievementResponse response =
-                achievementQueryService.getAchievements(GATHERING_ID, USER_ID_1);
+                achievementService.getAchievements(GATHERING_ID, USER_ID_1);
 
         // then
         assertThat(response.members()).hasSize(2);
@@ -114,7 +114,7 @@ class AchievementQueryServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                achievementQueryService.getAchievements(GATHERING_ID, USER_ID_1))
+                achievementService.getAchievements(GATHERING_ID, USER_ID_1))
                 .isInstanceOf(BusinessException.class);
     }
 }

--- a/src/test/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationServiceTest.java
@@ -698,31 +698,7 @@ class GatheringApplicationServiceTest {
             assertThat(response.applications().get(1).gathering().title()).isEqualTo("Spring Study");
         }
 
-        @Test
-        @DisplayName("신청에 대응되는 모임 정보가 없으면 예외가 발생한다")
-        void getMyApplications_fail_missingGathering() {
-            GatheringApplication application = GatheringApplication.builder()
-                    .gatheringId(100L)
-                    .applicantId(200L)
-                    .personalGoal("목표1")
-                    .selfIntroduction("소개1")
-                    .status(ApplicationStatus.PENDING)
-                    .build();
-            setField(application, "id", 1L);
-
-            when(userClient.existsById(200L)).thenReturn(true);
-            when(gatheringApplicationRepository.findByApplicantIdOrderByCreatedAtDesc(200L))
-                    .thenReturn(List.of(application));
-            when(gatheringRepository.findAllById(List.of(100L)))
-                    .thenReturn(List.of());
-
-            assertThatThrownBy(() -> gatheringApplicationService.getMyApplications(200L))
-                    .isInstanceOf(BusinessException.class)
-                    .extracting(ex -> ((BusinessException) ex).getErrorCode())
-                    .isEqualTo(ErrorCode.GATHERING_NOT_FOUND);
-        }
     }
-
 
     private void setField(Object target, String fieldName, Object value) {
         try {

--- a/src/test/java/com/fesi/deadlinemate/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/todo/service/TodoServiceTest.java
@@ -8,7 +8,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fesi.deadlinemate.domain.achievement.service.AchievementService;
 import com.fesi.deadlinemate.domain.gathering.entity.Gathering;
+import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
+import com.fesi.deadlinemate.domain.gathering.entity.GatheringRole;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringStatus;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringType;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
@@ -63,6 +66,9 @@ class TodoServiceTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private AchievementService achievementService;
 
     @InjectMocks
     private TodoService todoService;
@@ -298,6 +304,8 @@ class TodoServiceTest {
             todoService.delete(100L, 1L, 200L);
 
             verify(todoRepository).delete(todo);
+            verify(todoRepository).flush();
+            verify(achievementService).sync(100L, 200L);
 
             ArgumentCaptor<TodoDeletedEvent> eventCaptor = ArgumentCaptor.forClass(TodoDeletedEvent.class);
             verify(eventPublisher).publishEvent(eventCaptor.capture());
@@ -339,6 +347,24 @@ class TodoServiceTest {
             setField(todo2, "id", 2L);
             setField(todo2, "createdAt", LocalDateTime.of(2025, 3, 22, 10, 0));
 
+            GatheringMember member1 = GatheringMember.builder()
+                    .gatheringId(100L)
+                    .userId(200L)
+                    .role(GatheringRole.LEADER)
+                    .personalGoal(null)
+                    .overallAchievementRate(BigDecimal.ZERO.setScale(1))
+                    .isActive(true)
+                    .build();
+
+            GatheringMember member2 = GatheringMember.builder()
+                    .gatheringId(100L)
+                    .userId(201L)
+                    .role(GatheringRole.MEMBER)
+                    .personalGoal(null)
+                    .overallAchievementRate(BigDecimal.ZERO.setScale(1))
+                    .isActive(true)
+                    .build();
+
             UserInfo user1 = UserInfo.builder()
                     .id(200L)
                     .nickname("유저1")
@@ -362,6 +388,8 @@ class TodoServiceTest {
             when(gatheringMemberRepository.existsByGatheringIdAndUserIdAndIsActiveTrue(100L, 200L)).thenReturn(true);
             when(todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(100L))
                     .thenReturn(List.of(todo1, todo2));
+            when(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(100L))
+                    .thenReturn(List.of(member1, member2));
             when(userClient.findByIds(List.of(200L, 201L))).thenReturn(userMap);
 
             TodoListResponse response = todoService.getTodos(100L, 200L, null);


### PR DESCRIPTION

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)


### 📑 변경 사항
- Todo 생성/수정/삭제 시 `GatheringMember.overallAchievementRate`가 갱신되도록 `sync` 로직 추가
- Achievement 계산 로직에서 반복 `filter` 구조를 제거하고 `groupBy` 기반으로 리팩터링
- 달성률 소수 자릿수를 **1자리로 통일**
- 비활성 멤버의 Todo가 조회에서 제외되도록 로직 보완

- `/members`, `/achievements`, `/todos` 간 **달성률 값 불일치 문제** 해결
- 기존 구현은 `members × todos × weeks` 구조로 반복 필터가 발생하여 **성능 비효율 존재**
- 모임 신청 시 모임이 존재하지 않아도 에러나지않도록 수정

### 🛠 테스트 결과
모두 정상 통과 하였습니다
