### PR TITLE
Refactor: N+1발생 시 쿼리 실행 수, 총 실행 시간 로그추가 및 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/fesi/deadlinemate/domain/achievement/controller/AchievementController.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/achievement/controller/AchievementController.java
@@ -2,7 +2,7 @@ package com.fesi.deadlinemate.domain.achievement.controller;
 
 import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementRankingResponse;
 import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementResponse;
-import com.fesi.deadlinemate.domain.achievement.service.AchievementService;
+import com.fesi.deadlinemate.domain.achievement.service.AchievementQueryService;
 import com.fesi.deadlinemate.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AchievementController {
 
-    private final AchievementService achievementService;
+    private final AchievementQueryService achievementQueryService;
 
     @GetMapping("/{gatheringId}/achievements")
     public ApiResponse<AchievementResponse> getAchievements(
@@ -25,7 +25,7 @@ public class AchievementController {
     ) {
         Long userId = (Long) authentication.getPrincipal();
         return ApiResponse.success(
-                achievementService.getAchievements(gatheringId, userId)
+                achievementQueryService.getAchievements(gatheringId, userId)
         );
     }
 
@@ -36,7 +36,7 @@ public class AchievementController {
     ) {
         Long userId = (Long) authentication.getPrincipal();
         return ApiResponse.success(
-                achievementService.getRanking(gatheringId, userId)
+                achievementQueryService.getRanking(gatheringId, userId)
         );
     }
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementQueryService.java
@@ -1,0 +1,247 @@
+package com.fesi.deadlinemate.domain.achievement.service;
+
+import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementRankingResponse;
+import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementResponse;
+import com.fesi.deadlinemate.domain.gathering.entity.Gathering;
+import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
+import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
+import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
+import com.fesi.deadlinemate.domain.todo.entity.Todo;
+import com.fesi.deadlinemate.domain.todo.repository.TodoRepository;
+import com.fesi.deadlinemate.domain.user.client.UserClient;
+import com.fesi.deadlinemate.domain.user.client.dto.UserInfo;
+import com.fesi.deadlinemate.global.error.BusinessException;
+import com.fesi.deadlinemate.global.error.ErrorCode;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AchievementQueryService {
+
+    private final GatheringRepository gatheringRepository;
+    private final GatheringMemberRepository gatheringMemberRepository;
+    private final TodoRepository todoRepository;
+    private final UserClient userClient;
+
+    public AchievementResponse getAchievements(Long gatheringId, Long requesterId) {
+        Gathering gathering = findGathering(gatheringId);
+        validateActiveMember(gatheringId, requesterId);
+
+        List<GatheringMember> activeMembers =
+                gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId);
+
+        Set<Long> activeUserIds = activeMembers.stream()
+                .map(GatheringMember::getUserId)
+                .collect(Collectors.toSet());
+
+        List<Todo> todos = todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId).stream()
+                .filter(todo -> activeUserIds.contains(todo.getUserId()))
+                .toList();
+
+        Map<Long, UserInfo> userMap = loadUsers(
+                activeMembers.stream()
+                        .map(GatheringMember::getUserId)
+                        .distinct()
+                        .toList()
+        );
+
+        Map<Long, List<Todo>> todosByUser = groupByUser(todos);
+        Map<Integer, List<Todo>> teamTodosByWeek = groupByWeek(todos);
+        Map<Long, Map<Integer, List<Todo>>> todosByUserAndWeek = groupByUserAndWeek(todos);
+
+        List<AchievementResponse.MemberAchievementResponse> memberResponses = activeMembers.stream()
+                .map(member -> {
+                    Long userId = member.getUserId();
+                    UserInfo user = userMap.get(userId);
+
+                    List<Todo> memberTodos = todosByUser.getOrDefault(userId, List.of());
+                    Map<Integer, List<Todo>> memberWeekMap = todosByUserAndWeek.getOrDefault(userId, Map.of());
+
+                    List<AchievementResponse.WeeklyRateResponse> weeklyRates =
+                            buildWeeklyRates(memberWeekMap, gathering.getTotalWeeks());
+
+                    BigDecimal overallRate = calculateOverallRate(memberTodos);
+
+                    return AchievementResponse.MemberAchievementResponse.builder()
+                            .userId(userId)
+                            .nickname(user != null ? user.getNickname() : null)
+                            .weeklyRates(weeklyRates)
+                            .overallRate(overallRate)
+                            .build();
+                })
+                .toList();
+
+        List<AchievementResponse.WeeklyRateResponse> teamWeeklyRates =
+                buildWeeklyRates(teamTodosByWeek, gathering.getTotalWeeks());
+
+        BigDecimal teamOverallRate = calculateOverallRate(todos);
+
+        return AchievementResponse.builder()
+                .members(memberResponses)
+                .teamWeeklyRates(teamWeeklyRates)
+                .teamOverallRate(teamOverallRate)
+                .build();
+    }
+
+    public AchievementRankingResponse getRanking(Long gatheringId, Long requesterId) {
+        Gathering gathering = findGathering(gatheringId);
+        validateActiveMember(gatheringId, requesterId);
+
+        List<GatheringMember> activeMembers =
+                gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId);
+
+        Set<Long> activeUserIds = activeMembers.stream()
+                .map(GatheringMember::getUserId)
+                .collect(Collectors.toSet());
+
+        List<Todo> todos = todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId).stream()
+                .filter(todo -> activeUserIds.contains(todo.getUserId()))
+                .toList();
+
+        Map<Long, UserInfo> userMap = loadUsers(
+                activeMembers.stream()
+                        .map(GatheringMember::getUserId)
+                        .distinct()
+                        .toList()
+        );
+
+        Map<Long, List<Todo>> todosByUser = groupByUser(todos);
+
+        List<MemberRateRow> memberRates = activeMembers.stream()
+                .map(member -> new MemberRateRow(
+                        member.getUserId(),
+                        calculateOverallRate(todosByUser.getOrDefault(member.getUserId(), List.of()))
+                ))
+                .sorted(Comparator
+                        .comparing(MemberRateRow::overallRate, Comparator.reverseOrder())
+                        .thenComparing(MemberRateRow::userId))
+                .toList();
+
+        List<AchievementRankingResponse.RankingItemResponse> ranking = new ArrayList<>();
+        for (int i = 0; i < memberRates.size(); i++) {
+            MemberRateRow row = memberRates.get(i);
+            UserInfo user = userMap.get(row.userId());
+
+            ranking.add(AchievementRankingResponse.RankingItemResponse.builder()
+                    .rank(i + 1)
+                    .userId(row.userId())
+                    .nickname(user != null ? user.getNickname() : null)
+                    .profileImage(user != null ? user.getProfileImage() : null)
+                    .overallRate(row.overallRate())
+                    .build());
+        }
+
+        return AchievementRankingResponse.of(ranking);
+    }
+
+
+    private Map<Long, List<Todo>> groupByUser(List<Todo> todos) {
+        return todos.stream()
+                .collect(Collectors.groupingBy(
+                        Todo::getUserId,
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+    }
+
+    private Map<Integer, List<Todo>> groupByWeek(List<Todo> todos) {
+        return todos.stream()
+                .collect(Collectors.groupingBy(
+                        Todo::getWeekNumber,
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+    }
+
+    private Map<Long, Map<Integer, List<Todo>>> groupByUserAndWeek(List<Todo> todos) {
+        return todos.stream()
+                .collect(Collectors.groupingBy(
+                        Todo::getUserId,
+                        LinkedHashMap::new,
+                        Collectors.groupingBy(
+                                Todo::getWeekNumber,
+                                LinkedHashMap::new,
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+
+    private Gathering findGathering(Long gatheringId) {
+        return gatheringRepository.findById(gatheringId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GATHERING_NOT_FOUND));
+    }
+
+    private void validateActiveMember(Long gatheringId, Long userId) {
+        boolean isActiveMember = gatheringMemberRepository
+                .existsByGatheringIdAndUserIdAndIsActiveTrue(gatheringId, userId);
+
+        if (!isActiveMember) {
+            throw new BusinessException(ErrorCode.NOT_A_MEMBER);
+        }
+    }
+
+    private List<AchievementResponse.WeeklyRateResponse> buildWeeklyRates(
+            Map<Integer, List<Todo>> todosByWeek,
+            int totalWeeks
+    ) {
+        List<AchievementResponse.WeeklyRateResponse> result = new ArrayList<>();
+
+        for (int week = 1; week <= totalWeeks; week++) {
+            List<Todo> weeklyTodos = todosByWeek.getOrDefault(week, List.of());
+
+            result.add(AchievementResponse.WeeklyRateResponse.builder()
+                    .week(week)
+                    .rate(calculateOverallRate(weeklyTodos))
+                    .build());
+        }
+
+        return result;
+    }
+
+    private BigDecimal calculateOverallRate(List<Todo> todos) {
+        if (todos == null || todos.isEmpty()) {
+            return BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
+        }
+
+        long totalCount = todos.size();
+        long completedCount = todos.stream()
+                .filter(Todo::isCompleted)
+                .count();
+
+        return BigDecimal.valueOf(completedCount)
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(totalCount), 1, RoundingMode.HALF_UP);
+    }
+
+
+    private Map<Long, UserInfo> loadUsers(List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Long> distinctUserIds = userIds.stream()
+                .distinct()
+                .toList();
+
+        return userClient.findByIds(distinctUserIds);
+    }
+
+    private record MemberRateRow(
+            Long userId,
+            BigDecimal overallRate
+    ) {
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementService.java
@@ -1,152 +1,26 @@
 package com.fesi.deadlinemate.domain.achievement.service;
 
-import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementRankingResponse;
-import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementResponse;
-import com.fesi.deadlinemate.domain.gathering.entity.Gathering;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
-import com.fesi.deadlinemate.domain.todo.entity.Todo;
 import com.fesi.deadlinemate.domain.todo.repository.TodoRepository;
 import com.fesi.deadlinemate.domain.user.client.UserClient;
-import com.fesi.deadlinemate.domain.user.client.dto.UserInfo;
 import com.fesi.deadlinemate.global.error.BusinessException;
 import com.fesi.deadlinemate.global.error.ErrorCode;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class AchievementService {
 
-    private final GatheringRepository gatheringRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
     private final TodoRepository todoRepository;
-    private final UserClient userClient;
 
-    public AchievementResponse getAchievements(Long gatheringId, Long requesterId) {
-        Gathering gathering = findGathering(gatheringId);
-        validateActiveMember(gatheringId, requesterId);
-
-        List<GatheringMember> activeMembers =
-                gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId);
-
-        Set<Long> activeUserIds = activeMembers.stream()
-                .map(GatheringMember::getUserId)
-                .collect(Collectors.toSet());
-
-        List<Todo> todos = todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId).stream()
-                .filter(todo -> activeUserIds.contains(todo.getUserId()))
-                .toList();
-
-        Map<Long, UserInfo> userMap = loadUsers(
-                activeMembers.stream()
-                        .map(GatheringMember::getUserId)
-                        .distinct()
-                        .toList()
-        );
-
-        Map<Long, List<Todo>> todosByUser = groupByUser(todos);
-        Map<Integer, List<Todo>> teamTodosByWeek = groupByWeek(todos);
-        Map<Long, Map<Integer, List<Todo>>> todosByUserAndWeek = groupByUserAndWeek(todos);
-
-        List<AchievementResponse.MemberAchievementResponse> memberResponses = activeMembers.stream()
-                .map(member -> {
-                    Long userId = member.getUserId();
-                    UserInfo user = userMap.get(userId);
-
-                    List<Todo> memberTodos = todosByUser.getOrDefault(userId, List.of());
-                    Map<Integer, List<Todo>> memberWeekMap = todosByUserAndWeek.getOrDefault(userId, Map.of());
-
-                    List<AchievementResponse.WeeklyRateResponse> weeklyRates =
-                            buildWeeklyRates(memberWeekMap, gathering.getTotalWeeks());
-
-                    BigDecimal overallRate = calculateOverallRate(memberTodos);
-
-                    return AchievementResponse.MemberAchievementResponse.builder()
-                            .userId(userId)
-                            .nickname(user != null ? user.getNickname() : null)
-                            .weeklyRates(weeklyRates)
-                            .overallRate(overallRate)
-                            .build();
-                })
-                .toList();
-
-        List<AchievementResponse.WeeklyRateResponse> teamWeeklyRates =
-                buildWeeklyRates(teamTodosByWeek, gathering.getTotalWeeks());
-
-        BigDecimal teamOverallRate = calculateOverallRate(todos);
-
-        return AchievementResponse.builder()
-                .members(memberResponses)
-                .teamWeeklyRates(teamWeeklyRates)
-                .teamOverallRate(teamOverallRate)
-                .build();
-    }
-
-    public AchievementRankingResponse getRanking(Long gatheringId, Long requesterId) {
-        Gathering gathering = findGathering(gatheringId);
-        validateActiveMember(gatheringId, requesterId);
-
-        List<GatheringMember> activeMembers =
-                gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId);
-
-        Set<Long> activeUserIds = activeMembers.stream()
-                .map(GatheringMember::getUserId)
-                .collect(Collectors.toSet());
-
-        List<Todo> todos = todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId).stream()
-                .filter(todo -> activeUserIds.contains(todo.getUserId()))
-                .toList();
-
-        Map<Long, UserInfo> userMap = loadUsers(
-                activeMembers.stream()
-                        .map(GatheringMember::getUserId)
-                        .distinct()
-                        .toList()
-        );
-
-        Map<Long, List<Todo>> todosByUser = groupByUser(todos);
-
-        List<MemberRateRow> memberRates = activeMembers.stream()
-                .map(member -> new MemberRateRow(
-                        member.getUserId(),
-                        calculateOverallRate(todosByUser.getOrDefault(member.getUserId(), List.of()))
-                ))
-                .sorted(Comparator
-                        .comparing(MemberRateRow::overallRate, Comparator.reverseOrder())
-                        .thenComparing(MemberRateRow::userId))
-                .toList();
-
-        List<AchievementRankingResponse.RankingItemResponse> ranking = new ArrayList<>();
-        for (int i = 0; i < memberRates.size(); i++) {
-            MemberRateRow row = memberRates.get(i);
-            UserInfo user = userMap.get(row.userId());
-
-            ranking.add(AchievementRankingResponse.RankingItemResponse.builder()
-                    .rank(i + 1)
-                    .userId(row.userId())
-                    .nickname(user != null ? user.getNickname() : null)
-                    .profileImage(user != null ? user.getProfileImage() : null)
-                    .overallRate(row.overallRate())
-                    .build());
-        }
-
-        return AchievementRankingResponse.of(ranking);
-    }
-
-    @Transactional
     public void sync(Long gatheringId, Long userId) {
         GatheringMember member = gatheringMemberRepository
                 .findByGatheringIdAndUserIdAndIsActiveTrue(gatheringId, userId)
@@ -162,103 +36,5 @@ public class AchievementService {
                         .divide(BigDecimal.valueOf(totalCount), 1, RoundingMode.HALF_UP);
 
         member.updateOverallAchievementRate(rate);
-    }
-
-    private Map<Long, List<Todo>> groupByUser(List<Todo> todos) {
-        return todos.stream()
-                .collect(Collectors.groupingBy(
-                        Todo::getUserId,
-                        LinkedHashMap::new,
-                        Collectors.toList()
-                ));
-    }
-
-    private Map<Integer, List<Todo>> groupByWeek(List<Todo> todos) {
-        return todos.stream()
-                .collect(Collectors.groupingBy(
-                        Todo::getWeekNumber,
-                        LinkedHashMap::new,
-                        Collectors.toList()
-                ));
-    }
-
-    private Map<Long, Map<Integer, List<Todo>>> groupByUserAndWeek(List<Todo> todos) {
-        return todos.stream()
-                .collect(Collectors.groupingBy(
-                        Todo::getUserId,
-                        LinkedHashMap::new,
-                        Collectors.groupingBy(
-                                Todo::getWeekNumber,
-                                LinkedHashMap::new,
-                                Collectors.toList()
-                        )
-                ));
-    }
-
-
-    private Gathering findGathering(Long gatheringId) {
-        return gatheringRepository.findById(gatheringId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.GATHERING_NOT_FOUND));
-    }
-
-    private void validateActiveMember(Long gatheringId, Long userId) {
-        boolean isActiveMember = gatheringMemberRepository
-                .existsByGatheringIdAndUserIdAndIsActiveTrue(gatheringId, userId);
-
-        if (!isActiveMember) {
-            throw new BusinessException(ErrorCode.NOT_A_MEMBER);
-        }
-    }
-
-    private List<AchievementResponse.WeeklyRateResponse> buildWeeklyRates(
-            Map<Integer, List<Todo>> todosByWeek,
-            int totalWeeks
-    ) {
-        List<AchievementResponse.WeeklyRateResponse> result = new ArrayList<>();
-
-        for (int week = 1; week <= totalWeeks; week++) {
-            List<Todo> weeklyTodos = todosByWeek.getOrDefault(week, List.of());
-
-            result.add(AchievementResponse.WeeklyRateResponse.builder()
-                    .week(week)
-                    .rate(calculateOverallRate(weeklyTodos))
-                    .build());
-        }
-
-        return result;
-    }
-
-    private BigDecimal calculateOverallRate(List<Todo> todos) {
-        if (todos == null || todos.isEmpty()) {
-            return BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
-        }
-
-        long totalCount = todos.size();
-        long completedCount = todos.stream()
-                .filter(Todo::isCompleted)
-                .count();
-
-        return BigDecimal.valueOf(completedCount)
-                .multiply(BigDecimal.valueOf(100))
-                .divide(BigDecimal.valueOf(totalCount), 1, RoundingMode.HALF_UP);
-    }
-
-
-    private Map<Long, UserInfo> loadUsers(List<Long> userIds) {
-        if (userIds == null || userIds.isEmpty()) {
-            return Map.of();
-        }
-
-        List<Long> distinctUserIds = userIds.stream()
-                .distinct()
-                .toList();
-
-        return userClient.findByIds(distinctUserIds);
-    }
-
-    private record MemberRateRow(
-            Long userId,
-            BigDecimal overallRate
-    ) {
     }
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/GatheringMember.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/GatheringMember.java
@@ -49,12 +49,14 @@ public class GatheringMember {
 
     @Builder
     public GatheringMember(Long gatheringId, Long userId, GatheringRole role,
-                           String personalGoal, boolean isActive) {
+                           String personalGoal, boolean isActive,
+                           BigDecimal overallAchievementRate) {
         this.gatheringId = gatheringId;
         this.userId = userId;
         this.role = role;
         this.personalGoal = personalGoal;
         this.isActive = isActive;
+        this.overallAchievementRate = overallAchievementRate;
     }
 
     public boolean isLeader() {

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringService.java
@@ -32,6 +32,7 @@ import com.fesi.deadlinemate.domain.user.client.UserClient;
 import com.fesi.deadlinemate.global.common.ImageStorageService;
 import com.fesi.deadlinemate.global.error.BusinessException;
 import com.fesi.deadlinemate.global.error.ErrorCode;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -648,6 +649,7 @@ public class GatheringService {
                 .role(GatheringRole.LEADER)
                 .personalGoal(null)
                 .isActive(true)
+                .overallAchievementRate(BigDecimal.ZERO)
                 .build();
 
         gatheringMemberRepository.save(leaderMember);

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryService.java
@@ -49,7 +49,6 @@ public class MembershipQueryService {
     private final GatheringCategoryRepository gatheringCategoryRepository;
     private final CategoryRepository categoryRepository;
     private final UserClient userClient;
-    private final TodoRepository todoRepository;
 
     public MyGatheringListResponse getMyGatherings(Long userId, String status, String sort, int page, int limit) {
         int validatedPage = Math.max(page, 1);
@@ -143,21 +142,10 @@ public class MembershipQueryService {
         Map<Long, BigDecimal> achievementRates = members.stream()
                 .collect(Collectors.toMap(
                         GatheringMember::getUserId,
-                        member -> calculateOverallAchievementRate(gatheringId, member.getUserId())
+                        GatheringMember::getOverallAchievementRate
                 ));
 
         return MemberListResponse.of(members, userMap, achievementRates);
-    }
-
-    private BigDecimal calculateOverallAchievementRate(Long gatheringId, Long userId) {
-        long totalCount = todoRepository.countByGatheringIdAndUserId(gatheringId, userId);
-        if (totalCount == 0) {
-            return BigDecimal.ZERO.setScale(1);
-        }
-        long completedCount = todoRepository.countByGatheringIdAndUserIdAndIsCompletedTrue(gatheringId, userId);
-        return BigDecimal.valueOf(completedCount)
-                .multiply(BigDecimal.valueOf(100))
-                .divide(BigDecimal.valueOf(totalCount), 1, RoundingMode.HALF_UP);
     }
 
     private Page<Gathering> resolveGatheringPage(List<Long> ids, String status, boolean isOldest, PageRequest pageable) {

--- a/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationService.java
@@ -24,6 +24,7 @@ import com.fesi.deadlinemate.domain.user.client.UserClient;
 import com.fesi.deadlinemate.domain.user.client.dto.UserInfo;
 import com.fesi.deadlinemate.global.error.BusinessException;
 import com.fesi.deadlinemate.global.error.ErrorCode;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -256,6 +257,7 @@ public class GatheringApplicationService {
                 .role(GatheringRole.MEMBER)
                 .personalGoal(application.getPersonalGoal())
                 .isActive(true)
+                .overallAchievementRate(BigDecimal.ZERO)
                 .build();
 
         try {

--- a/src/main/java/com/fesi/deadlinemate/domain/todo/service/TodoService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/todo/service/TodoService.java
@@ -1,5 +1,6 @@
 package com.fesi.deadlinemate.domain.todo.service;
 
+import com.fesi.deadlinemate.domain.achievement.service.AchievementQueryService;
 import com.fesi.deadlinemate.domain.achievement.service.AchievementService;
 import com.fesi.deadlinemate.domain.gathering.entity.Gathering;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;

--- a/src/main/java/com/fesi/deadlinemate/global/config/SchemaCompatibilityRunner.java
+++ b/src/main/java/com/fesi/deadlinemate/global/config/SchemaCompatibilityRunner.java
@@ -21,7 +21,6 @@ public class SchemaCompatibilityRunner implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
-        dropColumnIfExists("gathering_members", "overall_achievement_rate");
     }
 
     private void dropColumnIfExists(String tableName, String columnName) {

--- a/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryCountContext.java
+++ b/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryCountContext.java
@@ -1,0 +1,44 @@
+package com.fesi.deadlinemate.global.monitoring;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class QueryCountContext {
+
+    private static final ThreadLocal<QueryCountContext> HOLDER = new ThreadLocal<>();
+
+    // SQL 텍스트 → [실행횟수, 누적시간ms]
+    private final Map<String, long[]> sqlStats = new LinkedHashMap<>();
+
+    private QueryCountContext() {}
+
+    public static void initialize() {
+        HOLDER.set(new QueryCountContext());
+    }
+
+    public static QueryCountContext current() {
+        return HOLDER.get();
+    }
+
+    public static void clear() {
+        HOLDER.remove();
+    }
+
+    public void recordSql(String sql, long ms) {
+        sqlStats.merge(sql, new long[]{1, ms},
+                (prev, v) -> new long[]{prev[0] + 1, prev[1] + ms});
+    }
+
+    public boolean hasN1() {
+        return sqlStats.values().stream().anyMatch(v -> v[0] >= 2);
+    }
+
+    public long getTotalCount() {
+        return sqlStats.values().stream().mapToLong(v -> v[0]).sum();
+    }
+
+    public long getTotalTimeMs() {
+        return sqlStats.values().stream().mapToLong(v -> v[1]).sum();
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryCountingConnectionHandler.java
+++ b/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryCountingConnectionHandler.java
@@ -1,0 +1,56 @@
+package com.fesi.deadlinemate.global.monitoring;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+
+public final class QueryCountingConnectionHandler implements InvocationHandler {
+
+    private final Connection delegate;
+
+    public QueryCountingConnectionHandler(Connection delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        Object result;
+        try {
+            result = method.invoke(delegate, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+
+        String name = method.getName();
+        if ("createStatement".equals(name) && result instanceof Statement stmt) {
+            return wrapStatement(stmt, Statement.class, null);
+        }
+        if ("prepareStatement".equals(name) && result instanceof PreparedStatement ps) {
+            String sql = extractSql(args);
+            return wrapStatement(ps, PreparedStatement.class, sql);
+        }
+        if ("prepareCall".equals(name) && result instanceof CallableStatement cs) {
+            String sql = extractSql(args);
+            return wrapStatement(cs, CallableStatement.class, sql);
+        }
+        return result;
+    }
+
+    private String extractSql(Object[] args) {
+        if (args != null && args.length > 0 && args[0] instanceof String s) return s;
+        return null;
+    }
+
+    private <T> T wrapStatement(T stmt, Class<T> iface, String sql) {
+        return iface.cast(Proxy.newProxyInstance(
+                stmt.getClass().getClassLoader(),
+                new Class<?>[]{iface},
+                new QueryCountingStatementHandler(stmt, sql)
+        ));
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryCountingDataSourceWrapper.java
+++ b/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryCountingDataSourceWrapper.java
@@ -1,0 +1,65 @@
+package com.fesi.deadlinemate.global.monitoring;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+public final class QueryCountingDataSourceWrapper implements DataSource {
+
+    private final DataSource delegate;
+
+    public QueryCountingDataSourceWrapper(DataSource delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return wrap(delegate.getConnection());
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return wrap(delegate.getConnection(username, password));
+    }
+
+    private Connection wrap(Connection real) {
+        return (Connection) Proxy.newProxyInstance(
+                real.getClass().getClassLoader(),
+                new Class<?>[]{Connection.class},
+                new QueryCountingConnectionHandler(real)
+        );
+    }
+
+    // HikariCP compatibility: delegate unwrap so Hibernate can access the real pool
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (iface.isInstance(delegate)) {
+            return iface.cast(delegate);
+        }
+        return delegate.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return iface.isInstance(delegate) || delegate.isWrapperFor(iface);
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException { return delegate.getLogWriter(); }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException { delegate.setLogWriter(out); }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException { delegate.setLoginTimeout(seconds); }
+
+    @Override
+    public int getLoginTimeout() throws SQLException { return delegate.getLoginTimeout(); }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException { return delegate.getParentLogger(); }
+}

--- a/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryCountingStatementHandler.java
+++ b/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryCountingStatementHandler.java
@@ -1,0 +1,55 @@
+package com.fesi.deadlinemate.global.monitoring;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+public final class QueryCountingStatementHandler implements InvocationHandler {
+
+    private static final Set<String> EXECUTE_METHODS = Set.of(
+            "execute", "executeQuery", "executeUpdate",
+            "executeBatch", "executeLargeBatch", "executeLargeUpdate"
+    );
+
+    private final Object delegate;
+    private final String sql;
+
+    public QueryCountingStatementHandler(Object delegate, String sql) {
+        this.delegate = delegate;
+        this.sql = sql;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (!EXECUTE_METHODS.contains(method.getName())) {
+            return invokeDelegate(method, args);
+        }
+
+        QueryCountContext ctx = QueryCountContext.current();
+        if (ctx == null) {
+            return invokeDelegate(method, args);
+        }
+
+        long start = System.currentTimeMillis();
+        try {
+            return invokeDelegate(method, args);
+        } finally {
+            ctx.recordSql(resolveSql(method, args), System.currentTimeMillis() - start);
+        }
+    }
+
+    private String resolveSql(Method method, Object[] args) {
+        if (sql != null) return sql;
+        if (args != null && args.length > 0 && args[0] instanceof String s) return s;
+        return method.getName();
+    }
+
+    private Object invokeDelegate(Method method, Object[] args) throws Throwable {
+        try {
+            return method.invoke(delegate, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryLoggingAspect.java
+++ b/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryLoggingAspect.java
@@ -1,0 +1,51 @@
+package com.fesi.deadlinemate.global.monitoring;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+@Profile("local")
+@Slf4j
+public class QueryLoggingAspect {
+
+    @Around("@within(org.springframework.web.bind.annotation.RestController) && execution(public * *(..))")
+    public Object logQueryCount(ProceedingJoinPoint pjp) throws Throwable {
+        QueryCountContext.initialize();
+        try {
+            return pjp.proceed();
+        } finally {
+            logAndClear();
+        }
+    }
+
+    private void logAndClear() {
+        try {
+            QueryCountContext ctx = QueryCountContext.current();
+            if (ctx == null || !ctx.hasN1()) return;
+
+            String url = resolveUrl();
+            log.debug("Query Statistics: URL = {}, Query Count = {}, Query Time = {}(ms)",
+                    url, ctx.getTotalCount(), ctx.getTotalTimeMs());
+        } finally {
+            QueryCountContext.clear();
+        }
+    }
+
+    private String resolveUrl() {
+        try {
+            HttpServletRequest req = ((ServletRequestAttributes)
+                    RequestContextHolder.currentRequestAttributes()).getRequest();
+            return req.getMethod() + " " + req.getRequestURI();
+        } catch (IllegalStateException e) {
+            return "unknown";
+        }
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryLoggingBeanPostProcessor.java
+++ b/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryLoggingBeanPostProcessor.java
@@ -1,0 +1,30 @@
+package com.fesi.deadlinemate.global.monitoring;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import javax.sql.DataSource;
+
+@Configuration
+@Profile("local")
+public class QueryLoggingBeanPostProcessor {
+
+    // static: BeanPostProcessor must be instantiated before @Configuration beans to avoid lifecycle issues
+    @Bean
+    public static BeanPostProcessor dataSourceWrappingPostProcessor() {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName)
+                    throws BeansException {
+                if (bean instanceof DataSource ds
+                        && !(bean instanceof QueryCountingDataSourceWrapper)) {
+                    return new QueryCountingDataSourceWrapper(ds);
+                }
+                return bean;
+            }
+        };
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,10 @@ oauth:
     token-url: https://oauth2.googleapis.com/token
     user-info-url: https://www.googleapis.com/oauth2/v2/userinfo
 
+logging:
+  level:
+    com.fesi.deadlinemate.global.monitoring: DEBUG
+
 ---
 spring:
   config:

--- a/src/test/java/com/fesi/deadlinemate/domain/achievement/controller/AchievementControllerTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/achievement/controller/AchievementControllerTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementRankingResponse;
 import com.fesi.deadlinemate.domain.achievement.dto.response.AchievementResponse;
-import com.fesi.deadlinemate.domain.achievement.service.AchievementService;
+import com.fesi.deadlinemate.domain.achievement.service.AchievementQueryService;
 import com.fesi.deadlinemate.global.security.JwtTokenProvider;
 import java.math.BigDecimal;
 import java.util.List;
@@ -37,7 +37,7 @@ class AchievementControllerTest {
     private JwtTokenProvider jwtTokenProvider;
 
     @MockitoBean
-    private AchievementService achievementService;
+    private AchievementQueryService achievementQueryService;
 
     private String token;
     private AchievementResponse achievementResponse;
@@ -57,7 +57,7 @@ class AchievementControllerTest {
         @Test
         @DisplayName("인증된 사용자는 모임 전체 달성률 현황을 조회할 수 있다")
         void getAchievements_success() throws Exception {
-            given(achievementService.getAchievements(1L, 1L))
+            given(achievementQueryService.getAchievements(1L, 1L))
                     .willReturn(achievementResponse);
 
             mockMvc.perform(get("/api/v1/gatherings/{gatheringId}/achievements", 1L)
@@ -85,7 +85,7 @@ class AchievementControllerTest {
         @Test
         @DisplayName("인증된 사용자는 달성률 순위를 조회할 수 있다")
         void getRanking_success() throws Exception {
-            given(achievementService.getRanking(1L, 1L))
+            given(achievementQueryService.getRanking(1L, 1L))
                     .willReturn(rankingResponse);
 
             mockMvc.perform(get("/api/v1/gatherings/{gatheringId}/achievements/ranking", 1L)

--- a/src/test/java/com/fesi/deadlinemate/domain/achievement/service/AchievementQueryServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/achievement/service/AchievementQueryServiceTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class AchievementServiceTest {
+class AchievementQueryServiceTest {
 
     @Mock
     private GatheringRepository gatheringRepository;
@@ -42,7 +42,7 @@ class AchievementServiceTest {
     private UserClient userClient;
 
     @InjectMocks
-    private AchievementService achievementService;
+    private AchievementQueryService achievementQueryService;
 
     private final Long GATHERING_ID = 1L;
     private final Long USER_ID_1 = 10L;
@@ -95,7 +95,7 @@ class AchievementServiceTest {
 
         // when
         AchievementResponse response =
-                achievementService.getAchievements(GATHERING_ID, USER_ID_1);
+                achievementQueryService.getAchievements(GATHERING_ID, USER_ID_1);
 
         // then
         assertThat(response.members()).hasSize(2);
@@ -114,7 +114,7 @@ class AchievementServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                achievementService.getAchievements(GATHERING_ID, USER_ID_1))
+                achievementQueryService.getAchievements(GATHERING_ID, USER_ID_1))
                 .isInstanceOf(BusinessException.class);
     }
 }

--- a/src/test/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryServiceTest.java
@@ -55,7 +55,6 @@ class MembershipQueryServiceTest {
     @Mock private GatheringCategoryRepository gatheringCategoryRepository;
     @Mock private CategoryRepository categoryRepository;
     @Mock private UserClient userClient;
-    @Mock private TodoRepository todoRepository;
 
     @InjectMocks
     private MembershipQueryService membershipQueryService;
@@ -79,7 +78,7 @@ class MembershipQueryServiceTest {
         @DisplayName("참여 중인 모임 목록과 역할을 반환한다")
         void getMyGatherings() {
             Gathering gathering = gathering(1L, 3);
-            GatheringMember member = member(1L, 1L, 10L, GatheringRole.MEMBER);
+            GatheringMember member = member(1L, 1L, 10L, GatheringRole.MEMBER,"0.0");
 
             Category category = Category.builder().name("개발").build();
             setField(category, "id", 100L);
@@ -116,7 +115,7 @@ class MembershipQueryServiceTest {
         @DisplayName("sort=oldest이면 오름차순으로 조회한다")
         void getMyGatheringsOldest() {
             Gathering gathering = gathering(1L, 3);
-            GatheringMember member = member(1L, 1L, 10L, GatheringRole.MEMBER);
+            GatheringMember member = member(1L, 1L, 10L, GatheringRole.MEMBER,"0.0");
 
             given(gatheringMemberRepository.findActiveGatheringIdsByUserId(10L)).willReturn(List.of(1L));
             given(gatheringRepository.findByIdInOrderByCreatedAtAsc(any(), any(Pageable.class)))
@@ -138,7 +137,7 @@ class MembershipQueryServiceTest {
         @DisplayName("LEADER인 모임은 pendingApplicationCount를 반환한다")
         void leaderGetsPendingCount() {
             Gathering gathering = gathering(1L, 3);
-            GatheringMember member = member(1L, 1L, 10L, GatheringRole.LEADER);
+            GatheringMember member = member(1L, 1L, 10L, GatheringRole.LEADER,"0.0");
 
             given(gatheringMemberRepository.findActiveGatheringIdsByUserId(10L)).willReturn(List.of(1L));
             given(gatheringRepository.findByIdInOrderByCreatedAtDesc(any(), any(Pageable.class)))
@@ -163,7 +162,7 @@ class MembershipQueryServiceTest {
         @DisplayName("리뷰를 작성한 모임은 hasReviewed가 true이다")
         void hasReviewedTrue() {
             Gathering gathering = gathering(1L, 3);
-            GatheringMember member = member(1L, 1L, 10L, GatheringRole.MEMBER);
+            GatheringMember member = member(1L, 1L, 10L, GatheringRole.MEMBER,"0.0");
 
             given(gatheringMemberRepository.findActiveGatheringIdsByUserId(10L)).willReturn(List.of(1L));
             given(gatheringRepository.findByIdInOrderByCreatedAtDesc(any(), any(Pageable.class)))
@@ -189,14 +188,12 @@ class MembershipQueryServiceTest {
         @Test
         @DisplayName("배치로 유저 정보를 조회하여 멤버 목록을 반환한다")
         void getMembers() {
-            GatheringMember member = member(1L, 1L, 10L, GatheringRole.LEADER);
+            GatheringMember member = member(1L, 1L, 10L, GatheringRole.LEADER,"100.0");
             given(gatheringMemberRepository.existsByGatheringIdAndUserIdAndIsActiveTrue(1L, 10L)).willReturn(true);
             given(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(1L))
                     .willReturn(List.of(member));
             given(userClient.findByIds(List.of(10L))).willReturn(
                     Map.of(10L, UserInfo.builder().id(10L).nickname("leader").build()));
-            given(todoRepository.countByGatheringIdAndUserId(1L, 10L)).willReturn(4L);
-            given(todoRepository.countByGatheringIdAndUserIdAndIsCompletedTrue(1L, 10L)).willReturn(4L);
 
             MemberListResponse response = membershipQueryService.getMembers(1L, 10L);
 
@@ -208,13 +205,12 @@ class MembershipQueryServiceTest {
         @Test
         @DisplayName("할 일이 없는 멤버는 달성률 0.0%를 반환한다")
         void getMembersWithNoTodos() {
-            GatheringMember member = member(1L, 1L, 10L, GatheringRole.MEMBER);
+            GatheringMember member = member(1L, 1L, 10L, GatheringRole.MEMBER,"0.0");
             given(gatheringMemberRepository.existsByGatheringIdAndUserIdAndIsActiveTrue(1L, 10L)).willReturn(true);
             given(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(1L))
                     .willReturn(List.of(member));
             given(userClient.findByIds(List.of(10L))).willReturn(
                     Map.of(10L, UserInfo.builder().id(10L).nickname("member").build()));
-            given(todoRepository.countByGatheringIdAndUserId(1L, 10L)).willReturn(0L);
 
             MemberListResponse response = membershipQueryService.getMembers(1L, 10L);
 
@@ -225,14 +221,12 @@ class MembershipQueryServiceTest {
         @Test
         @DisplayName("일부 완료된 할 일이 있으면 달성률이 정확히 계산된다")
         void getMembersWithPartialCompletion() {
-            GatheringMember member = member(1L, 1L, 10L, GatheringRole.MEMBER);
+            GatheringMember member = member(1L, 1L, 10L, GatheringRole.MEMBER,"75.0");
             given(gatheringMemberRepository.existsByGatheringIdAndUserIdAndIsActiveTrue(1L, 10L)).willReturn(true);
             given(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(1L))
                     .willReturn(List.of(member));
             given(userClient.findByIds(List.of(10L))).willReturn(
                     Map.of(10L, UserInfo.builder().id(10L).nickname("member").build()));
-            given(todoRepository.countByGatheringIdAndUserId(1L, 10L)).willReturn(4L);
-            given(todoRepository.countByGatheringIdAndUserIdAndIsCompletedTrue(1L, 10L)).willReturn(3L);
 
             MemberListResponse response = membershipQueryService.getMembers(1L, 10L);
 
@@ -243,9 +237,9 @@ class MembershipQueryServiceTest {
         @Test
         @DisplayName("여러 멤버 각각의 달성률을 독립적으로 계산한다")
         void getMembersWithMultipleMembersHavingDifferentRates() {
-            GatheringMember leader = member(1L, 1L, 10L, GatheringRole.LEADER);
-            GatheringMember memberA = member(2L, 1L, 20L, GatheringRole.MEMBER);
-            GatheringMember memberB = member(3L, 1L, 30L, GatheringRole.MEMBER);
+            GatheringMember leader = member(1L, 1L, 10L, GatheringRole.LEADER,"100.0");
+            GatheringMember memberA = member(2L, 1L, 20L, GatheringRole.MEMBER,"0.0");
+            GatheringMember memberB = member(3L, 1L, 30L, GatheringRole.MEMBER,"50.0");
 
             given(gatheringMemberRepository.existsByGatheringIdAndUserIdAndIsActiveTrue(1L, 10L)).willReturn(true);
             given(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(1L))
@@ -255,15 +249,6 @@ class MembershipQueryServiceTest {
                     20L, UserInfo.builder().id(20L).nickname("memberA").build(),
                     30L, UserInfo.builder().id(30L).nickname("memberB").build()
             ));
-
-            // leader: 4/4 = 100%
-            given(todoRepository.countByGatheringIdAndUserId(1L, 10L)).willReturn(4L);
-            given(todoRepository.countByGatheringIdAndUserIdAndIsCompletedTrue(1L, 10L)).willReturn(4L);
-            // memberA: 0/0 = 0%
-            given(todoRepository.countByGatheringIdAndUserId(1L, 20L)).willReturn(0L);
-            // memberB: 1/2 = 50%
-            given(todoRepository.countByGatheringIdAndUserId(1L, 30L)).willReturn(2L);
-            given(todoRepository.countByGatheringIdAndUserIdAndIsCompletedTrue(1L, 30L)).willReturn(1L);
 
             MemberListResponse response = membershipQueryService.getMembers(1L, 10L);
 
@@ -296,9 +281,9 @@ class MembershipQueryServiceTest {
         }
     }
 
-    private GatheringMember member(Long id, Long gatheringId, Long userId, GatheringRole role) {
+    private GatheringMember member(Long id, Long gatheringId, Long userId, GatheringRole role,String overallAchievementRate) {
         GatheringMember m = GatheringMember.builder()
-                .gatheringId(gatheringId).userId(userId).role(role)
+                .gatheringId(gatheringId).userId(userId).role(role).overallAchievementRate(new BigDecimal(overallAchievementRate))
 .isActive(true).build();
         setField(m, "id", id);
         return m;


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #44 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> refactor/44/refactor-achievement-report

### 📑 변경 사항
1. AchievementService 조회/명령 유스케이스 분리
- 기존에 AchievementService에 조회 부분과 동기화 책임이 섞여 있었습니다. 도메인 변경 책임이 선명해지도록 그리고 의도가 명확해지도록 분리하였습니다.

2. 모임 멤버십 달성률 계산 제거 ( Todo에서 동기화 한 후 모임멤버 필드에 저장 )
- Todo가 생성,수정,삭제되면 GatheringMember의 달성률 필드가 저장되기 떄문에 MembershipQueryService애서 다시 계산할 필요없다고 판단되어 제거 및 저장된 값을 사용하는 방식으로 변경하였습니다.

3. 모임 생성 시 리더 달성률 0으로 저장
- 모임 생성 시 500에러가 발생했습니다. (MembershipQueryService.getMembers()에서 NullPointerException이 발생)
- 원인:  GatheringMember.getOverallAchievementRate()가 null을 반환하는 멤버가 있어서 Collectors.toMap()이 NPE를 던짐(saveLeaderMember()에서 overallAchievementRate를 빌더에 설정하지 않아 null로 저장)

4. N+1 디버그 위한 로거 추가
- 리팩토링을 통해 쿼리가 개선이 되었는지 확인하고 싶을 때 사용하기 위해 추가하였습니다.

### 🛠 테스트 결과
> 빌드테스트, 테스트 모두 통과하였습니다.

