### PR TITLE
Refactor:모임 정원 마감 시 신청 대기 거절 및 모임 조회 쿼리 최적화

### DIFF
--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryService.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -74,16 +75,25 @@ public class GatheringQueryService {
     public GatheringMainResponse getMainGatherings(int limit) {
         int validatedLimit = Math.max(limit, 1);
 
-        List<GatheringListItemResponse> popular =
-                toListItemResponses(gatheringRepository.findMainPopular(validatedLimit));
+        List<GatheringListRow> popularRows  = gatheringRepository.findMainPopular(validatedLimit);
+        List<GatheringListRow> deadlineRows = gatheringRepository.findMainDeadline(validatedLimit);
+        List<GatheringListRow> latestRows   = gatheringRepository.findMainLatest(validatedLimit);
 
-        List<GatheringListItemResponse> deadline =
-                toListItemResponses(gatheringRepository.findMainDeadline(validatedLimit));
+        List<GatheringListRow> allRows = Stream.of(popularRows, deadlineRows, latestRows)
+                .flatMap(List::stream)
+                .toList();
 
-        List<GatheringListItemResponse> latest =
-                toListItemResponses(gatheringRepository.findMainLatest(validatedLimit));
+        if (allRows.isEmpty()) {
+            return GatheringMainResponse.of(List.of(), List.of(), List.of());
+        }
 
-        return GatheringMainResponse.of(popular, deadline, latest);
+        RelatedData data = fetchRelatedData(allRows);
+
+        return GatheringMainResponse.of(
+                assembleResponses(popularRows,  data),
+                assembleResponses(deadlineRows, data),
+                assembleResponses(latestRows,   data)
+        );
     }
 
     public GatheringListResponse getMyLikedGatherings(Long userId, int page, int limit) {
@@ -196,13 +206,17 @@ public class GatheringQueryService {
                 .build();
     }
 
-    private List<GatheringListItemResponse> toListItemResponses(List<GatheringListRow> rows) {
-        if (rows.isEmpty()) {
-            return List.of();
-        }
+    private record RelatedData(
+            Map<Long, List<String>> tagsMap,
+            Map<Long, List<String>> imageUrlsMap,
+            Map<Long, List<String>> categoryMap,
+            Map<Long, UserInfo> leaderMap
+    ) {}
 
+    private RelatedData fetchRelatedData(List<GatheringListRow> rows) {
         List<Long> gatheringIds = rows.stream()
                 .map(GatheringListRow::id)
+                .distinct()
                 .toList();
 
         Map<Long, List<String>> tagsMap = gatheringTagRepository
@@ -229,18 +243,23 @@ public class GatheringQueryService {
                 rows.stream().map(GatheringListRow::leaderId).distinct().toList()
         );
 
+        return new RelatedData(tagsMap, imageUrlsMap, categoryMap, leaderMap);
+    }
+
+    private List<GatheringListItemResponse> assembleResponses(
+            List<GatheringListRow> rows, RelatedData data) {
         return rows.stream()
                 .map(row -> {
-                    UserInfo leader = leaderMap.get(row.leaderId());
+                    UserInfo leader = data.leaderMap().get(row.leaderId());
 
                     return GatheringListItemResponse.builder()
                             .id(row.id())
                             .type(row.type().getDisplayName())
-                            .categories(categoryMap.getOrDefault(row.id(), List.of()))
+                            .categories(data.categoryMap().getOrDefault(row.id(), List.of()))
                             .title(row.title())
                             .shortDescription(row.shortDescription())
-                            .imageUrls(imageUrlsMap.getOrDefault(row.id(), List.of()))
-                            .tags(tagsMap.getOrDefault(row.id(), List.of()))
+                            .imageUrls(data.imageUrlsMap().getOrDefault(row.id(), List.of()))
+                            .tags(data.tagsMap().getOrDefault(row.id(), List.of()))
                             .maxMembers(row.maxMembers())
                             .currentMembers(row.currentMembers())
                             .recruitDeadline(row.recruitDeadline())
@@ -255,6 +274,13 @@ public class GatheringQueryService {
                             .build();
                 })
                 .toList();
+    }
+
+    private List<GatheringListItemResponse> toListItemResponses(List<GatheringListRow> rows) {
+        if (rows.isEmpty()) {
+            return List.of();
+        }
+        return assembleResponses(rows, fetchRelatedData(rows));
     }
 
     private Map<Long, List<String>> buildCategoryMap(List<Long> gatheringIds) {

--- a/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/repository/GatheringApplicationRepository.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/repository/GatheringApplicationRepository.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -33,4 +34,22 @@ public interface GatheringApplicationRepository extends JpaRepository<GatheringA
 
     @Query("SELECT ga.gatheringId, COUNT(ga) FROM GatheringApplication ga WHERE ga.gatheringId IN :gatheringIds AND ga.status = :status GROUP BY ga.gatheringId")
     List<Object[]> countByGatheringIdInAndStatus(@Param("gatheringIds") List<Long> gatheringIds, @Param("status") ApplicationStatus status);
+
+    List<GatheringApplication> findByGatheringIdAndStatusAndIdNot(
+            Long gatheringId, ApplicationStatus status, Long excludeId);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("""
+        UPDATE GatheringApplication ga
+        SET ga.status = :rejected
+        WHERE ga.gatheringId = :gatheringId
+          AND ga.status = :pending
+          AND ga.id <> :acceptedApplicationId
+    """)
+    int rejectAllPendingExcept(
+            @Param("gatheringId") Long gatheringId,
+            @Param("acceptedApplicationId") Long acceptedApplicationId,
+            @Param("pending") ApplicationStatus pending,
+            @Param("rejected") ApplicationStatus rejected
+    );
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationService.java
@@ -266,6 +266,38 @@ public class GatheringApplicationService {
             throw new BusinessException(ErrorCode.ALREADY_GATHERING_MEMBER);
         }
         gathering.increaseCurrentMembers();
+
+        if (gathering.getCurrentMembers() >= gathering.getMaxMembers()) {
+            autoRejectRemainingPending(gathering, application.getId());
+        }
+    }
+
+    private void autoRejectRemainingPending(Gathering gathering, Long acceptedApplicationId) {
+        List<GatheringApplication> pendingApplications = gatheringApplicationRepository
+                .findByGatheringIdAndStatusAndIdNot(
+                        gathering.getId(), ApplicationStatus.PENDING, acceptedApplicationId);
+
+        if (pendingApplications.isEmpty()) {
+            return;
+        }
+
+        gatheringApplicationRepository.rejectAllPendingExcept(
+                gathering.getId(),
+                acceptedApplicationId,
+                ApplicationStatus.PENDING,
+                ApplicationStatus.REJECTED
+        );
+
+        for (GatheringApplication pending : pendingApplications) {
+            eventPublisher.publishEvent(new GatheringApplicationUpdatedEvent(
+                    pending.getId(),
+                    gathering.getId(),
+                    pending.getApplicantId(),
+                    gathering.getLeaderId(),
+                    gathering.getTitle(),
+                    ApplicationStatus.REJECTED
+            ));
+        }
     }
 
     private void rejectApplication(GatheringApplication application) {

--- a/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryLoggingAspect.java
+++ b/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryLoggingAspect.java
@@ -29,7 +29,7 @@ public class QueryLoggingAspect {
     private void logAndClear() {
         try {
             QueryCountContext ctx = QueryCountContext.current();
-            if (ctx == null || !ctx.hasN1()) return;
+            if (ctx == null) return;
 
             String url = resolveUrl();
             log.debug("Query Statistics: URL = {}, Query Count = {}, Query Time = {}(ms)",

--- a/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryLoggingAspect.java
+++ b/src/main/java/com/fesi/deadlinemate/global/monitoring/QueryLoggingAspect.java
@@ -32,8 +32,9 @@ public class QueryLoggingAspect {
             if (ctx == null) return;
 
             String url = resolveUrl();
-            log.debug("Query Statistics: URL = {}, Query Count = {}, Query Time = {}(ms)",
-                    url, ctx.getTotalCount(), ctx.getTotalTimeMs());
+            String prefix = ctx.hasN1() ? "[N+1] " : "";
+            log.debug("{}Query Statistics: URL = {}, Query Count = {}, Query Time = {}(ms)",
+                    prefix, url, ctx.getTotalCount(), ctx.getTotalTimeMs());
         } finally {
             QueryCountContext.clear();
         }

--- a/src/test/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.fesi.deadlinemate.domain.category.entity.Category;
 import com.fesi.deadlinemate.domain.category.entity.GatheringCategory;
@@ -122,6 +124,40 @@ class GatheringQueryServiceTest {
             assertThat(response.popular().get(0).title()).isEqualTo("React 스터디");
             assertThat(response.deadline()).isEmpty();
             assertThat(response.latest()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("3개 섹션 모두에 데이터가 있을 때 배치 쿼리가 1회만 실행된다")
+        void fetchesRelatedDataOnceForAllSections() {
+            GatheringListRow row1 = sampleRow(1L, 10L);
+            GatheringListRow row2 = sampleRow(2L, 20L);
+            GatheringListRow row3 = sampleRow(3L, 30L);
+            given(gatheringRepository.findMainPopular(5)).willReturn(List.of(row1));
+            given(gatheringRepository.findMainDeadline(5)).willReturn(List.of(row2));
+            given(gatheringRepository.findMainLatest(5)).willReturn(List.of(row3));
+
+            List<Long> allIds = List.of(1L, 2L, 3L);
+            given(gatheringTagRepository.findByGatheringIdInOrderByGatheringIdAscIdAsc(allIds))
+                    .willReturn(List.of());
+            given(gatheringCategoryRepository.findByGatheringIdIn(allIds))
+                    .willReturn(List.of());
+            given(categoryRepository.findByIdIn(anyList())).willReturn(List.of());
+            given(userClient.findByIds(anyList())).willReturn(Map.of(
+                    10L, UserInfo.builder().id(10L).nickname("리더1").profileImage(null).build(),
+                    20L, UserInfo.builder().id(20L).nickname("리더2").profileImage(null).build(),
+                    30L, UserInfo.builder().id(30L).nickname("리더3").profileImage(null).build()
+            ));
+
+            GatheringMainResponse response = gatheringQueryService.getMainGatherings(5);
+
+            assertThat(response.popular()).hasSize(1);
+            assertThat(response.deadline()).hasSize(1);
+            assertThat(response.latest()).hasSize(1);
+            verify(gatheringTagRepository, times(1))
+                    .findByGatheringIdInOrderByGatheringIdAscIdAsc(allIds);
+            verify(gatheringCategoryRepository, times(1))
+                    .findByGatheringIdIn(allIds);
+            verify(userClient, times(1)).findByIds(anyList());
         }
     }
 

--- a/src/test/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationConcurrencyTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationConcurrencyTest.java
@@ -115,7 +115,8 @@ class GatheringApplicationConcurrencyTest {
                 successCount.incrementAndGet();
             } catch (BusinessException e) {
                 if (e.getErrorCode() == ErrorCode.GATHERING_FULL) fullCount.incrementAndGet();
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             } finally {
                 doneLatch.countDown();
             }
@@ -133,15 +134,17 @@ class GatheringApplicationConcurrencyTest {
                 successCount.incrementAndGet();
             } catch (BusinessException e) {
                 if (e.getErrorCode() == ErrorCode.GATHERING_FULL) fullCount.incrementAndGet();
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             } finally {
                 doneLatch.countDown();
             }
         });
 
         startLatch.countDown();
-        doneLatch.await(5, TimeUnit.SECONDS);
+        boolean completed = doneLatch.await(5, TimeUnit.SECONDS);
         executor.shutdown();
+        assertThat(completed).as("두 스레드가 5초 내에 완료되어야 합니다").isTrue();
 
         Gathering refreshed = gatheringRepository.findById(gathering.getId()).orElseThrow();
         assertThat(successCount.get()).isEqualTo(1);

--- a/src/test/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationConcurrencyTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/gatheringApplication/service/GatheringApplicationConcurrencyTest.java
@@ -1,0 +1,185 @@
+package com.fesi.deadlinemate.domain.gatheringApplication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fesi.deadlinemate.domain.gathering.entity.Gathering;
+import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
+import com.fesi.deadlinemate.domain.gathering.entity.GatheringRole;
+import com.fesi.deadlinemate.domain.gathering.entity.GatheringStatus;
+import com.fesi.deadlinemate.domain.gathering.entity.GatheringType;
+import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
+import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
+import com.fesi.deadlinemate.domain.gatheringApplication.command.UpdateApplicationCommand;
+import com.fesi.deadlinemate.domain.gatheringApplication.entity.ApplicationStatus;
+import com.fesi.deadlinemate.domain.gatheringApplication.entity.GatheringApplication;
+import com.fesi.deadlinemate.domain.gatheringApplication.repository.GatheringApplicationRepository;
+import com.fesi.deadlinemate.global.error.BusinessException;
+import com.fesi.deadlinemate.global.error.ErrorCode;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class GatheringApplicationConcurrencyTest {
+
+    @Autowired private GatheringApplicationService service;
+    @Autowired private GatheringRepository gatheringRepository;
+    @Autowired private GatheringApplicationRepository applicationRepository;
+    @Autowired private GatheringMemberRepository memberRepository;
+
+    private static final Long LEADER_ID   = 100L;
+    private static final Long APPLICANT_A = 101L;
+    private static final Long APPLICANT_B = 102L;
+
+    private Gathering gathering;
+
+    @BeforeEach
+    void setUp() {
+        gathering = gatheringRepository.save(Gathering.builder()
+                .leaderId(LEADER_ID)
+                .type(GatheringType.STUDY)
+                .title("동시성 테스트 스터디")
+                .shortDescription("짧은 소개")
+                .description("상세 설명")
+                .goal("목표")
+                .maxMembers(2)
+                .currentMembers(1)
+                .recruitDeadline(LocalDate.of(2099, 12, 1))
+                .startDate(LocalDate.of(2099, 12, 15))
+                .endDate(LocalDate.of(2100, 3, 15))
+                .totalWeeks(13)
+                .status(GatheringStatus.RECRUITING)
+                .viewCount(0)
+                .build());
+
+        memberRepository.save(GatheringMember.builder()
+                .gatheringId(gathering.getId())
+                .userId(LEADER_ID)
+                .role(GatheringRole.LEADER)
+                .isActive(true)
+                .overallAchievementRate(BigDecimal.ZERO)
+                .build());
+    }
+
+    @AfterEach
+    void cleanup() {
+        applicationRepository.deleteAll();
+        memberRepository.deleteAll();
+        gatheringRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("정원 1명 남은 모임에 동시 수락 시도 시 한 명만 성공한다")
+    void 동시_수락_시_정원_초과_방지() throws InterruptedException {
+        GatheringApplication appA = applicationRepository.save(GatheringApplication.builder()
+                .gatheringId(gathering.getId())
+                .applicantId(APPLICANT_A)
+                .personalGoal("열심히 하겠습니다")
+                .status(ApplicationStatus.PENDING)
+                .build());
+
+        GatheringApplication appB = applicationRepository.save(GatheringApplication.builder()
+                .gatheringId(gathering.getId())
+                .applicantId(APPLICANT_B)
+                .personalGoal("열심히 하겠습니다")
+                .status(ApplicationStatus.PENDING)
+                .build());
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch  = new CountDownLatch(2);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger fullCount    = new AtomicInteger(0);
+
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                service.updateApplication(UpdateApplicationCommand.builder()
+                        .gatheringId(gathering.getId())
+                        .applicationId(appA.getId())
+                        .requesterId(LEADER_ID)
+                        .status(ApplicationStatus.ACCEPTED)
+                        .build());
+                successCount.incrementAndGet();
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.GATHERING_FULL) fullCount.incrementAndGet();
+            } catch (InterruptedException ignored) {
+            } finally {
+                doneLatch.countDown();
+            }
+        });
+
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                service.updateApplication(UpdateApplicationCommand.builder()
+                        .gatheringId(gathering.getId())
+                        .applicationId(appB.getId())
+                        .requesterId(LEADER_ID)
+                        .status(ApplicationStatus.ACCEPTED)
+                        .build());
+                successCount.incrementAndGet();
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.GATHERING_FULL) fullCount.incrementAndGet();
+            } catch (InterruptedException ignored) {
+            } finally {
+                doneLatch.countDown();
+            }
+        });
+
+        startLatch.countDown();
+        doneLatch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        Gathering refreshed = gatheringRepository.findById(gathering.getId()).orElseThrow();
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(fullCount.get()).isEqualTo(1);
+        assertThat(refreshed.getCurrentMembers()).isEqualTo(2);
+        assertThat(memberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gathering.getId())).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("수락으로 정원이 꽉 찼을 때 나머지 PENDING 신청은 자동으로 거절된다")
+    void 수락_후_정원_마감_시_나머지_PENDING_자동_거절() {
+        GatheringApplication appA = applicationRepository.save(GatheringApplication.builder()
+                .gatheringId(gathering.getId())
+                .applicantId(APPLICANT_A)
+                .personalGoal("열심히 하겠습니다")
+                .status(ApplicationStatus.PENDING)
+                .build());
+
+        GatheringApplication appB = applicationRepository.save(GatheringApplication.builder()
+                .gatheringId(gathering.getId())
+                .applicantId(APPLICANT_B)
+                .personalGoal("열심히 하겠습니다")
+                .status(ApplicationStatus.PENDING)
+                .build());
+
+        service.updateApplication(UpdateApplicationCommand.builder()
+                .gatheringId(gathering.getId())
+                .applicationId(appA.getId())
+                .requesterId(LEADER_ID)
+                .status(ApplicationStatus.ACCEPTED)
+                .build());
+
+        GatheringApplication refreshedA = applicationRepository.findById(appA.getId()).orElseThrow();
+        GatheringApplication refreshedB = applicationRepository.findById(appB.getId()).orElseThrow();
+        Gathering refreshed = gatheringRepository.findById(gathering.getId()).orElseThrow();
+
+        assertThat(refreshedA.getStatus()).isEqualTo(ApplicationStatus.ACCEPTED);
+        assertThat(refreshedB.getStatus()).isEqualTo(ApplicationStatus.REJECTED);
+        assertThat(refreshed.getCurrentMembers()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #44 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> refactor/44/refactor-achoievement-report -> dev

### 📑 변경 사항
1. 모임 조회 시 같은 배치 쿼리 패턴을 3번 반복하는 문제
- 원인: toListItemResponses한번 호출 시 내부에서 쿼리 5개 실행(tags, images, categories, category names, users) 
-  해결: 데이터 결과를 묶어 전달 위한 레코드 도입, DB조회 부분 별도 메서드 분리, 데이터 1번만 조회하고 조립은 목록별로 수행

2. 모임 모집 정원 마감돼도 나머지 신청 PENDING으로 남아 신청 목록 오염시키는 문제
- 모임 정원이 다 차면 나머지 신청 대기는 REJECTD 처리
- 신청 동시성 테스트 추가

3. 쿼리 로그 로직 수정
- 상황: 유사 쿼리 반복 문제를 확인 할 수 있으나 해결하고 나서 개선된 수치를 확인하지 못함
- 해결: 모든 요청시 쿼리로그를 확인할 수 있으나 유사 쿼리 반복 문제가 발생한다면 앞에 표시해서 구분하도록 설정

### 🛠 테스트 결과
빌드테스트, 테스트 코드 모두 통과함을 확인하였습니다.