### PR TITLE
Refactor: 동점처리 정책 변경, 누락된 인덱스 추가

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -274,10 +274,11 @@ gatherings ───────────────────────
 | `id` | BIGINT | NOT NULL | PK | Auto Increment |
 | `gathering_id` | BIGINT | NOT NULL | FK → gatherings.id | UNIQUE (1:1) |
 | `team_overall_rate` | DECIMAL(5,2) | NOT NULL | | 팀 전체 달성률 |
-| `mvp_user_id` | BIGINT | NULL | FK → users.id | MVP |
-| `longest_streak_user_id` | BIGINT | NULL | FK → users.id | 최장 스트릭 |
-| `most_improved_user_id` | BIGINT | NULL | FK → users.id | 가장 성장한 멤버 |
-| `attendance_user_id` | BIGINT | NULL | FK → users.id | 매주 Todo 1개 이상 완료한 멤버 |
+| `mvp_user_ids` | TEXT | NULL | | MVP 수상자 목록 (공동수상 지원, JSON 배열) |
+| `longest_streak_user_ids` | TEXT | NULL | | 최장 스트릭 수상자 목록 (JSON 배열) |
+| `longest_streak_value` | INT | NOT NULL | | 최장 연속 100% 주차 수 |
+| `most_improved_user_ids` | TEXT | NULL | | 가장 성장한 멤버 목록 (JSON 배열) |
+| `attendance_user_ids` | TEXT | NULL | | 매주 Todo 1개 이상 완료한 멤버 목록 (JSON 배열) |
 | `weekly_rates` | JSON | NOT NULL | | `[{ "week": 1, "rate": 80.0 }, ...]` |
 | `created_at` | TIMESTAMP | NOT NULL | | 생성일시 |
 

--- a/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementQueryService.java
@@ -46,9 +46,8 @@ public class AchievementQueryService {
                 .map(GatheringMember::getUserId)
                 .collect(Collectors.toSet());
 
-        List<Todo> todos = todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId).stream()
-                .filter(todo -> activeUserIds.contains(todo.getUserId()))
-                .toList();
+        List<Todo> todos = todoRepository
+                .findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(gatheringId, activeUserIds);
 
         Map<Long, UserInfo> userMap = loadUsers(
                 activeMembers.stream()
@@ -106,9 +105,8 @@ public class AchievementQueryService {
                 .map(GatheringMember::getUserId)
                 .collect(Collectors.toSet());
 
-        List<Todo> todos = todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId).stream()
-                .filter(todo -> activeUserIds.contains(todo.getUserId()))
-                .toList();
+        List<Todo> todos = todoRepository
+                .findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(gatheringId, activeUserIds);
 
         Map<Long, UserInfo> userMap = loadUsers(
                 activeMembers.stream()

--- a/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementQueryService.java
@@ -122,18 +122,19 @@ public class AchievementQueryService {
                         member.getUserId(),
                         calculateOverallRate(todosByUser.getOrDefault(member.getUserId(), List.of()))
                 ))
-                .sorted(Comparator
-                        .comparing(MemberRateRow::overallRate, Comparator.reverseOrder())
-                        .thenComparing(MemberRateRow::userId))
+                .sorted(Comparator.comparing(MemberRateRow::overallRate, Comparator.reverseOrder()))
                 .toList();
 
         List<AchievementRankingResponse.RankingItemResponse> ranking = new ArrayList<>();
+        int rank = 1;
         for (int i = 0; i < memberRates.size(); i++) {
             MemberRateRow row = memberRates.get(i);
+            if (i > 0 && row.overallRate().compareTo(memberRates.get(i - 1).overallRate()) != 0) {
+                rank = i + 1;
+            }
             UserInfo user = userMap.get(row.userId());
-
             ranking.add(AchievementRankingResponse.RankingItemResponse.builder()
-                    .rank(i + 1)
+                    .rank(rank)
                     .userId(row.userId())
                     .nickname(user != null ? user.getNickname() : null)
                     .profileImage(user != null ? user.getProfileImage() : null)

--- a/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementService.java
@@ -2,9 +2,7 @@ package com.fesi.deadlinemate.domain.achievement.service;
 
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
-import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
 import com.fesi.deadlinemate.domain.todo.repository.TodoRepository;
-import com.fesi.deadlinemate.domain.user.client.UserClient;
 import com.fesi.deadlinemate.global.error.BusinessException;
 import com.fesi.deadlinemate.global.error.ErrorCode;
 import java.math.BigDecimal;

--- a/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/achievement/service/AchievementService.java
@@ -5,8 +5,8 @@ import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberReposito
 import com.fesi.deadlinemate.domain.todo.repository.TodoRepository;
 import com.fesi.deadlinemate.global.error.BusinessException;
 import com.fesi.deadlinemate.global.error.ErrorCode;
+import com.fesi.deadlinemate.global.common.AchievementRateCalculator;
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,11 +27,7 @@ public class AchievementService {
         long totalCount = todoRepository.countByGatheringIdAndUserId(gatheringId, userId);
         long completedCount = todoRepository.countByGatheringIdAndUserIdAndIsCompletedTrue(gatheringId, userId);
 
-        BigDecimal rate = totalCount == 0
-                ? BigDecimal.ZERO
-                : BigDecimal.valueOf(completedCount)
-                        .multiply(BigDecimal.valueOf(100))
-                        .divide(BigDecimal.valueOf(totalCount), 1, RoundingMode.HALF_UP);
+        BigDecimal rate = AchievementRateCalculator.calculateRate(completedCount, totalCount);
 
         member.updateOverallAchievementRate(rate);
     }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/GatheringMember.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/GatheringMember.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.math.BigDecimal;
@@ -19,7 +20,10 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "gathering_members",
-        uniqueConstraints = @UniqueConstraint(name = "uk_gathering_members_user", columnNames = {"gatheringId", "userId"}))
+        uniqueConstraints = @UniqueConstraint(name = "uk_gathering_members_user", columnNames = {"gatheringId", "userId"}),
+        indexes = {
+                @Index(name = "idx_gathering_members_user_is_active", columnList = "userId, isActive")
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GatheringMember {

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/GatheringTag.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/GatheringTag.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,7 +17,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "gathering_tags")
+@Table(name = "gathering_tags",
+        indexes = {
+                @Index(name = "idx_gathering_tags_gathering_id", columnList = "gatheringId")
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GatheringTag extends BaseTimeEntity {

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/WeeklyPlan.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/entity/WeeklyPlan.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AccessLevel;
@@ -15,7 +16,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "weekly_plans")
+@Table(name = "weekly_plans",
+        indexes = {
+                @Index(name = "idx_weekly_plans_gathering_id", columnList = "gatheringId")
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeeklyPlan extends BaseTimeEntity {

--- a/src/main/java/com/fesi/deadlinemate/domain/report/dto/GatheringReportResponse.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/dto/GatheringReportResponse.java
@@ -42,12 +42,13 @@ public record GatheringReportResponse(
 
     @Builder
     public record AwardsResponse(
-            UserAwardResponse mvp,
-            StreakAwardResponse longestStreak,
-            UserAwardResponse mostImproved,
-            UserAwardResponse attendance
+            List<UserAwardResponse> mvp,
+            List<StreakAwardResponse> longestStreak,
+            List<UserAwardResponse> mostImproved,
+            List<UserAwardResponse> attendance
     ) {
     }
+
 
     @Builder
     public record UserAwardResponse(

--- a/src/main/java/com/fesi/deadlinemate/domain/report/entity/GatheringReport.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/entity/GatheringReport.java
@@ -1,7 +1,9 @@
 package com.fesi.deadlinemate.domain.report.entity;
 
 import com.fesi.deadlinemate.global.common.BaseTimeEntity;
+import com.fesi.deadlinemate.global.common.LongListConverter;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -9,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,13 +33,21 @@ public class GatheringReport extends BaseTimeEntity {
     @Column(nullable = false, precision = 5, scale = 2)
     private BigDecimal teamOverallRate;
 
-    private Long mvpUserId;
+    @Convert(converter = LongListConverter.class)
+    @Column
+    private List<Long> mvpUserIds;
 
-    private Long longestStreakUserId;
+    @Convert(converter = LongListConverter.class)
+    @Column
+    private List<Long> longestStreakUserIds;
 
-    private Long mostImprovedUserId;
+    @Convert(converter = LongListConverter.class)
+    @Column
+    private List<Long> mostImprovedUserIds;
 
-    private Long attendanceUserId;
+    @Convert(converter = LongListConverter.class)
+    @Column
+    private List<Long> attendanceUserIds;
 
     @Lob
     @Column(nullable = false, columnDefinition = "json")
@@ -46,18 +57,18 @@ public class GatheringReport extends BaseTimeEntity {
     public GatheringReport(
             Long gatheringId,
             BigDecimal teamOverallRate,
-            Long mvpUserId,
-            Long longestStreakUserId,
-            Long mostImprovedUserId,
-            Long attendanceUserId,
+            List<Long> mvpUserIds,
+            List<Long> longestStreakUserIds,
+            List<Long> mostImprovedUserIds,
+            List<Long> attendanceUserIds,
             String weeklyRates
     ) {
         this.gatheringId = gatheringId;
         this.teamOverallRate = teamOverallRate;
-        this.mvpUserId = mvpUserId;
-        this.longestStreakUserId = longestStreakUserId;
-        this.mostImprovedUserId = mostImprovedUserId;
-        this.attendanceUserId = attendanceUserId;
+        this.mvpUserIds = mvpUserIds;
+        this.longestStreakUserIds = longestStreakUserIds;
+        this.mostImprovedUserIds = mostImprovedUserIds;
+        this.attendanceUserIds = attendanceUserIds;
         this.weeklyRates = weeklyRates;
     }
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/report/entity/GatheringReport.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/entity/GatheringReport.java
@@ -34,20 +34,23 @@ public class GatheringReport extends BaseTimeEntity {
     private BigDecimal teamOverallRate;
 
     @Convert(converter = LongListConverter.class)
-    @Column
+    @Column(columnDefinition = "TEXT")
     private List<Long> mvpUserIds;
 
     @Convert(converter = LongListConverter.class)
-    @Column
+    @Column(columnDefinition = "TEXT")
     private List<Long> longestStreakUserIds;
 
     @Convert(converter = LongListConverter.class)
-    @Column
+    @Column(columnDefinition = "TEXT")
     private List<Long> mostImprovedUserIds;
 
     @Convert(converter = LongListConverter.class)
-    @Column
+    @Column(columnDefinition = "TEXT")
     private List<Long> attendanceUserIds;
+
+    @Column(nullable = false)
+    private int longestStreakValue;
 
     @Lob
     @Column(nullable = false, columnDefinition = "json")
@@ -59,6 +62,7 @@ public class GatheringReport extends BaseTimeEntity {
             BigDecimal teamOverallRate,
             List<Long> mvpUserIds,
             List<Long> longestStreakUserIds,
+            int longestStreakValue,
             List<Long> mostImprovedUserIds,
             List<Long> attendanceUserIds,
             String weeklyRates
@@ -67,6 +71,7 @@ public class GatheringReport extends BaseTimeEntity {
         this.teamOverallRate = teamOverallRate;
         this.mvpUserIds = mvpUserIds;
         this.longestStreakUserIds = longestStreakUserIds;
+        this.longestStreakValue = longestStreakValue;
         this.mostImprovedUserIds = mostImprovedUserIds;
         this.attendanceUserIds = attendanceUserIds;
         this.weeklyRates = weeklyRates;

--- a/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryService.java
@@ -22,10 +22,8 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,12 +56,10 @@ public class GatheringReportQueryService {
                 .distinct()
                 .toList();
 
-        Set<Long> userIdSet = new HashSet<>(userIds);
         Map<Long, UserInfo> userMap = loadUsers(userIds);
 
-        List<Todo> todos = todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId).stream()
-                .filter(todo -> userIdSet.contains(todo.getUserId()))
-                .toList();
+        List<Todo> todos = todoRepository
+                .findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(gatheringId, userIds);
 
         List<GatheringReportResponse.MemberResultResponse> memberResults = activeMembers.stream()
                 .map(member -> toMemberResult(member.getUserId(), gathering.getTotalWeeks(), todos, userMap))

--- a/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryService.java
@@ -13,6 +13,7 @@ import com.fesi.deadlinemate.domain.report.dto.WeeklyRateDto;
 import com.fesi.deadlinemate.domain.report.entity.GatheringReport;
 import com.fesi.deadlinemate.domain.report.repository.GatheringReportRepository;
 import com.fesi.deadlinemate.domain.todo.entity.Todo;
+import com.fesi.deadlinemate.global.common.AchievementRateCalculator;
 import com.fesi.deadlinemate.domain.todo.repository.TodoRepository;
 import com.fesi.deadlinemate.domain.user.client.UserClient;
 import com.fesi.deadlinemate.domain.user.client.dto.UserInfo;
@@ -122,7 +123,7 @@ public class GatheringReportQueryService {
                 .filter(Todo::isCompleted)
                 .count();
 
-        BigDecimal overallRate = calculateRate(completedTodos, totalTodos);
+        BigDecimal overallRate = AchievementRateCalculator.calculateRate(completedTodos, totalTodos);
 
         List<BigDecimal> weeklyRates = new ArrayList<>();
         for (int week = 1; week <= totalWeeks; week++) {
@@ -137,7 +138,7 @@ public class GatheringReportQueryService {
                     .filter(Todo::isCompleted)
                     .count();
 
-            weeklyRates.add(calculateRate(weekCompleted, weekTotal));
+            weeklyRates.add(AchievementRateCalculator.calculateRate(weekCompleted, weekTotal));
         }
 
         int longestStreak = calculateLongestPerfectStreak(weeklyRates);
@@ -153,16 +154,6 @@ public class GatheringReportQueryService {
                 .totalTodos(totalTodos)
                 .weeklyRates(weeklyRates)
                 .build();
-    }
-
-    private BigDecimal calculateRate(long completedCount, long totalCount) {
-        if (totalCount == 0) {
-            return BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
-        }
-
-        return BigDecimal.valueOf(completedCount)
-                .multiply(BigDecimal.valueOf(100))
-                .divide(BigDecimal.valueOf(totalCount), 1, RoundingMode.HALF_UP);
     }
 
     private int calculateLongestPerfectStreak(List<BigDecimal> weeklyRates) {

--- a/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryService.java
@@ -70,7 +70,7 @@ public class GatheringReportQueryService {
 
         GatheringReportResponse.AwardsResponse awards = GatheringReportResponse.AwardsResponse.builder()
                 .mvp(toUserAwards(report.getMvpUserIds(), userMap))
-                .longestStreak(toStreakAwards(report.getLongestStreakUserIds(), memberResults, userMap))
+                .longestStreak(toStreakAwards(report.getLongestStreakUserIds(), report.getLongestStreakValue(), userMap))
                 .mostImproved(toUserAwards(report.getMostImprovedUserIds(), userMap))
                 .attendance(toUserAwards(report.getAttendanceUserIds(), userMap))
                 .build();
@@ -213,7 +213,7 @@ public class GatheringReportQueryService {
 
     private List<GatheringReportResponse.StreakAwardResponse> toStreakAwards(
             List<Long> userIds,
-            List<GatheringReportResponse.MemberResultResponse> memberResults,
+            int streakValue,
             Map<Long, UserInfo> userMap
     ) {
         if (userIds == null || userIds.isEmpty()) {
@@ -222,11 +222,6 @@ public class GatheringReportQueryService {
 
         return userIds.stream()
                 .map(userId -> {
-                    int streak = memberResults.stream()
-                            .filter(result -> result.userId().equals(userId))
-                            .map(GatheringReportResponse.MemberResultResponse::longestStreak)
-                            .findFirst()
-                            .orElse(0);
                     UserInfo user = userMap.get(userId);
                     if (user == null) {
                         user = userClient.findById(userId);
@@ -234,7 +229,7 @@ public class GatheringReportQueryService {
                     return GatheringReportResponse.StreakAwardResponse.builder()
                             .userId(userId)
                             .nickname(user != null ? user.getNickname() : null)
-                            .streak(streak)
+                            .streak(streakValue)
                             .build();
                 })
                 .toList();

--- a/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryService.java
@@ -68,10 +68,10 @@ public class GatheringReportQueryService {
         List<GatheringReportResponse.WeeklyRateResponse> teamWeeklyRates = parseWeeklyRates(report.getWeeklyRates());
 
         GatheringReportResponse.AwardsResponse awards = GatheringReportResponse.AwardsResponse.builder()
-                .mvp(toUserAward(report.getMvpUserId(), userMap))
-                .longestStreak(toStreakAward(report.getLongestStreakUserId(), memberResults, userMap))
-                .mostImproved(toUserAward(report.getMostImprovedUserId(), userMap))
-                .attendance(toUserAward(report.getAttendanceUserId(), userMap))
+                .mvp(toUserAwards(report.getMvpUserIds(), userMap))
+                .longestStreak(toStreakAwards(report.getLongestStreakUserIds(), memberResults, userMap))
+                .mostImproved(toUserAwards(report.getMostImprovedUserIds(), userMap))
+                .attendance(toUserAwards(report.getAttendanceUserIds(), userMap))
                 .build();
 
         return GatheringReportResponse.builder()
@@ -198,50 +198,55 @@ public class GatheringReportQueryService {
         }
     }
 
-    private GatheringReportResponse.UserAwardResponse toUserAward(
-            Long userId,
+    private List<GatheringReportResponse.UserAwardResponse> toUserAwards(
+            List<Long> userIds,
             Map<Long, UserInfo> userMap
     ) {
-        if (userId == null) {
-            return null;
+        if (userIds == null || userIds.isEmpty()) {
+            return List.of();
         }
 
-        UserInfo user = userMap.get(userId);
-        if (user == null) {
-            user = userClient.findById(userId);
-        }
-
-        return GatheringReportResponse.UserAwardResponse.builder()
-                .userId(userId)
-                .nickname(user != null ? user.getNickname() : null)
-                .build();
+        return userIds.stream()
+                .map(userId -> {
+                    UserInfo user = userMap.get(userId);
+                    if (user == null) {
+                        user = userClient.findById(userId);
+                    }
+                    return GatheringReportResponse.UserAwardResponse.builder()
+                            .userId(userId)
+                            .nickname(user != null ? user.getNickname() : null)
+                            .build();
+                })
+                .toList();
     }
 
-    private GatheringReportResponse.StreakAwardResponse toStreakAward(
-            Long userId,
+    private List<GatheringReportResponse.StreakAwardResponse> toStreakAwards(
+            List<Long> userIds,
             List<GatheringReportResponse.MemberResultResponse> memberResults,
             Map<Long, UserInfo> userMap
     ) {
-        if (userId == null) {
-            return null;
+        if (userIds == null || userIds.isEmpty()) {
+            return List.of();
         }
 
-        Integer streak = memberResults.stream()
-                .filter(result -> result.userId().equals(userId))
-                .map(GatheringReportResponse.MemberResultResponse::longestStreak)
-                .findFirst()
-                .orElse(0);
-
-        UserInfo user = userMap.get(userId);
-        if (user == null) {
-            user = userClient.findById(userId);
-        }
-
-        return GatheringReportResponse.StreakAwardResponse.builder()
-                .userId(userId)
-                .nickname(user != null ? user.getNickname() : null)
-                .streak(streak)
-                .build();
+        return userIds.stream()
+                .map(userId -> {
+                    int streak = memberResults.stream()
+                            .filter(result -> result.userId().equals(userId))
+                            .map(GatheringReportResponse.MemberResultResponse::longestStreak)
+                            .findFirst()
+                            .orElse(0);
+                    UserInfo user = userMap.get(userId);
+                    if (user == null) {
+                        user = userClient.findById(userId);
+                    }
+                    return GatheringReportResponse.StreakAwardResponse.builder()
+                            .userId(userId)
+                            .nickname(user != null ? user.getNickname() : null)
+                            .streak(streak)
+                            .build();
+                })
+                .toList();
     }
 
     private Map<Long, UserInfo> loadUsers(List<Long> userIds) {

--- a/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
@@ -83,43 +83,47 @@ public class GatheringReportService {
                 ))
                 .toList();
 
-        Long mvpUserId = memberRows.stream()
-                .max(Comparator
-                        .comparing(MemberReportRow::overallRate)
-                        .thenComparing(MemberReportRow::userId, Comparator.reverseOrder()))
-                .map(MemberReportRow::userId)
+        BigDecimal maxRate = memberRows.stream()
+                .map(MemberReportRow::overallRate)
+                .max(Comparator.naturalOrder())
                 .orElse(null);
-
-        Long longestStreakUserId = memberRows.stream()
-                .max(Comparator
-                        .comparingInt(MemberReportRow::longestStreak)
-                        .thenComparing(MemberReportRow::userId, Comparator.reverseOrder()))
+        List<Long> mvpUserIds = maxRate == null ? List.of() : memberRows.stream()
+                .filter(row -> row.overallRate().compareTo(maxRate) == 0)
                 .map(MemberReportRow::userId)
-                .orElse(null);
+                .toList();
 
-        Long mostImprovedUserId = memberRows.stream()
-                .max(Comparator
-                        .comparing(MemberReportRow::improvement)
-                        .thenComparing(MemberReportRow::userId, Comparator.reverseOrder()))
+        int maxStreak = memberRows.stream()
+                .mapToInt(MemberReportRow::longestStreak)
+                .max()
+                .orElse(0);
+        List<Long> longestStreakUserIds = memberRows.stream()
+                .filter(row -> row.longestStreak() == maxStreak)
                 .map(MemberReportRow::userId)
-                .orElse(null);
+                .toList();
 
-        Long attendanceUserId = memberRows.stream()
+        BigDecimal maxImprovement = memberRows.stream()
+                .map(MemberReportRow::improvement)
+                .max(Comparator.naturalOrder())
+                .orElse(null);
+        List<Long> mostImprovedUserIds = maxImprovement == null ? List.of() : memberRows.stream()
+                .filter(row -> row.improvement().compareTo(maxImprovement) == 0)
+                .map(MemberReportRow::userId)
+                .toList();
+
+        List<Long> attendanceUserIds = memberRows.stream()
                 .filter(MemberReportRow::attendanceAwardWinner)
                 .map(MemberReportRow::userId)
-                .sorted()
-                .findFirst()
-                .orElse(null);
+                .toList();
 
         String weeklyRatesJson = writeWeeklyRates(teamWeeklyRates);
 
         GatheringReport report = GatheringReport.builder()
                 .gatheringId(gatheringId)
                 .teamOverallRate(teamOverallRate.setScale(1, RoundingMode.HALF_UP))
-                .mvpUserId(mvpUserId)
-                .longestStreakUserId(longestStreakUserId)
-                .mostImprovedUserId(mostImprovedUserId)
-                .attendanceUserId(attendanceUserId)
+                .mvpUserIds(mvpUserIds)
+                .longestStreakUserIds(longestStreakUserIds)
+                .mostImprovedUserIds(mostImprovedUserIds)
+                .attendanceUserIds(attendanceUserIds)
                 .weeklyRates(weeklyRatesJson)
                 .build();
 

--- a/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
@@ -19,11 +19,9 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -63,11 +61,8 @@ public class GatheringReportService {
                 .distinct()
                 .toList();
 
-        Set<Long> userIdSet = new HashSet<>(userIds);
-
-        List<Todo> todos = todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId).stream()
-                .filter(todo -> userIdSet.contains(todo.getUserId()))
-                .toList();
+        List<Todo> todos = todoRepository
+                .findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(gatheringId, userIds);
 
         Map<Long, List<Todo>> todosByUser = groupByUser(todos);
         Map<Integer, List<Todo>> teamTodosByWeek = groupByWeek(todos);

--- a/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
@@ -10,6 +10,7 @@ import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
 import com.fesi.deadlinemate.domain.gathering.event.GatheringMemberEvaluatedEvent;
 import com.fesi.deadlinemate.domain.report.dto.WeeklyRateDto;
 import com.fesi.deadlinemate.domain.report.entity.GatheringReport;
+import com.fesi.deadlinemate.global.common.AchievementRateCalculator;
 import com.fesi.deadlinemate.domain.report.repository.GatheringReportRepository;
 import com.fesi.deadlinemate.domain.todo.entity.Todo;
 import com.fesi.deadlinemate.domain.todo.repository.TodoRepository;
@@ -69,7 +70,7 @@ public class GatheringReportService {
         Map<Long, Map<Integer, List<Todo>>> todosByUserAndWeek = groupByUserAndWeek(todos);
 
         List<WeeklyRateDto> teamWeeklyRates = buildWeeklyRates(teamTodosByWeek, gathering.getTotalWeeks());
-        BigDecimal teamOverallRate = calculateRate(
+        BigDecimal teamOverallRate = AchievementRateCalculator.calculateRate(
                 todos.stream().filter(Todo::isCompleted).count(),
                 todos.size()
         );
@@ -185,7 +186,7 @@ public class GatheringReportService {
 
             result.add(new WeeklyRateDto(
                     week,
-                    calculateRate(completedCount, totalCount)
+                    AchievementRateCalculator.calculateRate(completedCount, totalCount)
             ));
         }
 
@@ -203,7 +204,7 @@ public class GatheringReportService {
                 .filter(Todo::isCompleted)
                 .count();
 
-        BigDecimal overallRate = calculateRate(completedTodos, totalTodos);
+        BigDecimal overallRate = AchievementRateCalculator.calculateRate(completedTodos, totalTodos);
 
         List<BigDecimal> weeklyRates = new ArrayList<>();
         for (int week = 1; week <= totalWeeks; week++) {
@@ -214,7 +215,7 @@ public class GatheringReportService {
                     .filter(Todo::isCompleted)
                     .count();
 
-            weeklyRates.add(calculateRate(weekCompleted, weekTotal));
+            weeklyRates.add(AchievementRateCalculator.calculateRate(weekCompleted, weekTotal));
         }
 
         int longestStreak = calculateLongestPerfectStreak(weeklyRates);
@@ -229,16 +230,6 @@ public class GatheringReportService {
                 improvement,
                 attendanceAwardWinner
         );
-    }
-
-    private BigDecimal calculateRate(long completedCount, long totalCount) {
-        if (totalCount == 0) {
-            return BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
-        }
-
-        return BigDecimal.valueOf(completedCount)
-                .multiply(BigDecimal.valueOf(100))
-                .divide(BigDecimal.valueOf(totalCount), 1, RoundingMode.HALF_UP);
     }
 
     private int calculateLongestPerfectStreak(List<BigDecimal> weeklyRates) {

--- a/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
@@ -124,6 +124,7 @@ public class GatheringReportService {
                 .teamOverallRate(teamOverallRate.setScale(1, RoundingMode.HALF_UP))
                 .mvpUserIds(mvpUserIds)
                 .longestStreakUserIds(longestStreakUserIds)
+                .longestStreakValue(maxStreak)
                 .mostImprovedUserIds(mostImprovedUserIds)
                 .attendanceUserIds(attendanceUserIds)
                 .weeklyRates(weeklyRatesJson)

--- a/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/report/service/GatheringReportService.java
@@ -96,7 +96,7 @@ public class GatheringReportService {
                 .mapToInt(MemberReportRow::longestStreak)
                 .max()
                 .orElse(0);
-        List<Long> longestStreakUserIds = memberRows.stream()
+        List<Long> longestStreakUserIds = maxStreak == 0 ? List.of() : memberRows.stream()
                 .filter(row -> row.longestStreak() == maxStreak)
                 .map(MemberReportRow::userId)
                 .toList();
@@ -105,7 +105,8 @@ public class GatheringReportService {
                 .map(MemberReportRow::improvement)
                 .max(Comparator.naturalOrder())
                 .orElse(null);
-        List<Long> mostImprovedUserIds = maxImprovement == null ? List.of() : memberRows.stream()
+        List<Long> mostImprovedUserIds = (maxImprovement == null || maxImprovement.compareTo(BigDecimal.ZERO) <= 0)
+                ? List.of() : memberRows.stream()
                 .filter(row -> row.improvement().compareTo(maxImprovement) == 0)
                 .map(MemberReportRow::userId)
                 .toList();

--- a/src/main/java/com/fesi/deadlinemate/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/todo/repository/TodoRepository.java
@@ -1,6 +1,7 @@
 package com.fesi.deadlinemate.domain.todo.repository;
 
 import com.fesi.deadlinemate.domain.todo.entity.Todo;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     Optional<Todo> findByIdAndGatheringId(Long todoId, Long gatheringId);
     List<Todo> findByGatheringIdAndUserIdOrderByWeekNumberAscCreatedAtAsc(Long gatheringId, Long userId);
     List<Todo> findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(Long gatheringId);
+    List<Todo> findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(Long gatheringId, Collection<Long> userIds);
     List<Todo> findByGatheringIdAndWeekNumberOrderByCreatedAtAsc(Long gatheringId, int weekNumber);
     List<Todo> findByGatheringIdAndUserIdAndWeekNumberOrderByCreatedAtAsc(Long gatheringId, Long userId, int weekNumber);
     long countByGatheringIdAndUserId(Long gatheringId, Long userId);

--- a/src/main/java/com/fesi/deadlinemate/domain/todo/service/TodoService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/todo/service/TodoService.java
@@ -1,7 +1,7 @@
 package com.fesi.deadlinemate.domain.todo.service;
 
-import com.fesi.deadlinemate.domain.achievement.service.AchievementQueryService;
 import com.fesi.deadlinemate.domain.achievement.service.AchievementService;
+import com.fesi.deadlinemate.global.common.AchievementRateCalculator;
 import com.fesi.deadlinemate.domain.gathering.entity.Gathering;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
@@ -262,7 +262,7 @@ public class TodoService {
                 gathering.getId(), userId, targetWeek
         );
 
-        return calculateRate(completedCount, totalCount);
+        return AchievementRateCalculator.calculateRate(completedCount, totalCount);
     }
 
     private Integer resolveWeekForRead(Gathering gathering, Integer requestedWeek) {
@@ -286,18 +286,8 @@ public class TodoService {
 
     private BigDecimal calculateOverallAchievementRate(Long gatheringId, Long userId) {
         long totalCount = todoRepository.countByGatheringIdAndUserId(gatheringId, userId);
-        if (totalCount == 0) {
-            return BigDecimal.ZERO.setScale(1);
-        }
-
         long completedCount = todoRepository.countByGatheringIdAndUserIdAndIsCompletedTrue(gatheringId, userId);
-        return calculateRate(completedCount, totalCount);
-    }
-
-    private BigDecimal calculateRate(long completedCount, long totalCount) {
-        return BigDecimal.valueOf(completedCount)
-                .multiply(BigDecimal.valueOf(100))
-                .divide(BigDecimal.valueOf(totalCount), 1, RoundingMode.HALF_UP);
+        return AchievementRateCalculator.calculateRate(completedCount, totalCount);
     }
 
     private Map<Long, UserInfo> loadUsers(List<Long> userIds) {

--- a/src/main/java/com/fesi/deadlinemate/global/common/AchievementRateCalculator.java
+++ b/src/main/java/com/fesi/deadlinemate/global/common/AchievementRateCalculator.java
@@ -1,0 +1,18 @@
+package com.fesi.deadlinemate.global.common;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public final class AchievementRateCalculator {
+
+    private AchievementRateCalculator() {}
+
+    public static BigDecimal calculateRate(long completedCount, long totalCount) {
+        if (totalCount == 0) {
+            return BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
+        }
+        return BigDecimal.valueOf(completedCount)
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(totalCount), 1, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/global/common/LongListConverter.java
+++ b/src/main/java/com/fesi/deadlinemate/global/common/LongListConverter.java
@@ -1,0 +1,40 @@
+package com.fesi.deadlinemate.global.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.List;
+
+@Converter
+public class LongListConverter implements AttributeConverter<List<Long>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<Long> list) {
+        if (list == null || list.isEmpty()) {
+            return "[]";
+        }
+        try {
+            return objectMapper.writeValueAsString(list);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("List<Long> JSON 직렬화 실패", e);
+        }
+    }
+
+    @Override
+    public List<Long> convertToEntityAttribute(String json) {
+        if (json == null || json.isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(
+                    json,
+                    objectMapper.getTypeFactory().constructCollectionType(List.class, Long.class)
+            );
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("List<Long> JSON 역직렬화 실패: " + json, e);
+        }
+    }
+}

--- a/src/main/java/com/fesi/deadlinemate/global/common/LongListConverter.java
+++ b/src/main/java/com/fesi/deadlinemate/global/common/LongListConverter.java
@@ -34,7 +34,7 @@ public class LongListConverter implements AttributeConverter<List<Long>, String>
                     objectMapper.getTypeFactory().constructCollectionType(List.class, Long.class)
             );
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("List<Long> JSON 역직렬화 실패: " + json, e);
+            throw new IllegalArgumentException("List<Long> JSON 역직렬화 실패", e);
         }
     }
 }

--- a/src/test/java/com/fesi/deadlinemate/domain/achievement/service/AchievementQueryServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/achievement/service/AchievementQueryServiceTest.java
@@ -3,6 +3,8 @@ package com.fesi.deadlinemate.domain.achievement.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -81,7 +83,8 @@ class AchievementQueryServiceTest {
         when(todo2.getWeekNumber()).thenReturn(1);
         when(todo2.isCompleted()).thenReturn(false);
 
-        when(todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(GATHERING_ID))
+        when(todoRepository.findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(
+                eq(GATHERING_ID), anyCollection()))
                 .thenReturn(List.of(todo1, todo2));
 
         UserInfo user1 = mock(UserInfo.class);

--- a/src/test/java/com/fesi/deadlinemate/domain/report/controller/GatheringReportControllerTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/report/controller/GatheringReportControllerTest.java
@@ -65,7 +65,7 @@ class GatheringReportControllerTest {
                     .andExpect(jsonPath("$.data.gathering.title").value("React 완전 정복 스터디"))
                     .andExpect(jsonPath("$.data.teamOverallRate").value(82.5))
                     .andExpect(jsonPath("$.data.memberResults[0].userId").value(1))
-                    .andExpect(jsonPath("$.data.awards.mvp.nickname").value("모임장"));
+                    .andExpect(jsonPath("$.data.awards.mvp[0].nickname").value("모임장"));
         }
 
         @Test
@@ -109,23 +109,23 @@ class GatheringReportControllerTest {
                                 .build()
                 ))
                 .awards(GatheringReportResponse.AwardsResponse.builder()
-                        .mvp(GatheringReportResponse.UserAwardResponse.builder()
+                        .mvp(List.of(GatheringReportResponse.UserAwardResponse.builder()
                                 .userId(1L)
                                 .nickname("모임장")
-                                .build())
-                        .longestStreak(GatheringReportResponse.StreakAwardResponse.builder()
+                                .build()))
+                        .longestStreak(List.of(GatheringReportResponse.StreakAwardResponse.builder()
                                 .userId(1L)
                                 .nickname("모임장")
                                 .streak(2)
-                                .build())
-                        .mostImproved(GatheringReportResponse.UserAwardResponse.builder()
+                                .build()))
+                        .mostImproved(List.of(GatheringReportResponse.UserAwardResponse.builder()
                                 .userId(2L)
                                 .nickname("멤버")
-                                .build())
-                        .attendance(GatheringReportResponse.UserAwardResponse.builder()
+                                .build()))
+                        .attendance(List.of(GatheringReportResponse.UserAwardResponse.builder()
                                 .userId(1L)
                                 .nickname("모임장")
-                                .build())
+                                .build()))
                         .build())
                 .build();
     }

--- a/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryServiceTest.java
@@ -3,6 +3,8 @@ package com.fesi.deadlinemate.domain.report.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -120,7 +122,8 @@ class GatheringReportQueryServiceTest {
         when(gatheringReportRepository.findByGatheringId(gatheringId)).thenReturn(Optional.of(report));
         when(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId))
                 .thenReturn(List.of(leader, member));
-        when(todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId))
+        when(todoRepository.findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(
+                eq(gatheringId), anyCollection()))
                 .thenReturn(todos);
 
         when(userClient.findById(100L)).thenReturn(userInfo(100L, "마감왕", "leader.png"));
@@ -267,7 +270,8 @@ class GatheringReportQueryServiceTest {
         when(gatheringReportRepository.findByGatheringId(gatheringId)).thenReturn(Optional.of(report));
         when(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId))
                 .thenReturn(List.of(leader));
-        when(todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId))
+        when(todoRepository.findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(
+                eq(gatheringId), anyCollection()))
                 .thenReturn(List.of(todo(gatheringId, 100L, 1, true)));
         when(userClient.findById(100L)).thenReturn(userInfo(100L, "마감왕", "leader.png"));
 

--- a/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryServiceTest.java
@@ -77,10 +77,10 @@ class GatheringReportQueryServiceTest {
         GatheringReport report = GatheringReport.builder()
                 .gatheringId(gatheringId)
                 .teamOverallRate(new BigDecimal("78.50"))
-                .mvpUserId(100L)
-                .longestStreakUserId(100L)
-                .mostImprovedUserId(200L)
-                .attendanceUserId(100L)
+                .mvpUserIds(List.of(100L))
+                .longestStreakUserIds(List.of(100L))
+                .mostImprovedUserIds(List.of(200L))
+                .attendanceUserIds(List.of(100L))
                 .weeklyRates("""
                         [
                           {"week":1,"rate":90.0},
@@ -172,18 +172,22 @@ class GatheringReportQueryServiceTest {
         assertThat(memberResult.completedTodos()).isEqualTo(3);
         assertThat(memberResult.totalTodos()).isEqualTo(8);
 
-        assertThat(response.awards().mvp().userId()).isEqualTo(100L);
-        assertThat(response.awards().mvp().nickname()).isEqualTo("마감왕");
+        assertThat(response.awards().mvp()).hasSize(1);
+        assertThat(response.awards().mvp().get(0).userId()).isEqualTo(100L);
+        assertThat(response.awards().mvp().get(0).nickname()).isEqualTo("마감왕");
 
-        assertThat(response.awards().longestStreak().userId()).isEqualTo(100L);
-        assertThat(response.awards().longestStreak().nickname()).isEqualTo("마감왕");
-        assertThat(response.awards().longestStreak().streak()).isEqualTo(2);
+        assertThat(response.awards().longestStreak()).hasSize(1);
+        assertThat(response.awards().longestStreak().get(0).userId()).isEqualTo(100L);
+        assertThat(response.awards().longestStreak().get(0).nickname()).isEqualTo("마감왕");
+        assertThat(response.awards().longestStreak().get(0).streak()).isEqualTo(2);
 
-        assertThat(response.awards().mostImproved().userId()).isEqualTo(200L);
-        assertThat(response.awards().mostImproved().nickname()).isEqualTo("성장맨");
+        assertThat(response.awards().mostImproved()).hasSize(1);
+        assertThat(response.awards().mostImproved().get(0).userId()).isEqualTo(200L);
+        assertThat(response.awards().mostImproved().get(0).nickname()).isEqualTo("성장맨");
 
-        assertThat(response.awards().attendance().userId()).isEqualTo(100L);
-        assertThat(response.awards().attendance().nickname()).isEqualTo("마감왕");
+        assertThat(response.awards().attendance()).hasSize(1);
+        assertThat(response.awards().attendance().get(0).userId()).isEqualTo(100L);
+        assertThat(response.awards().attendance().get(0).nickname()).isEqualTo("마감왕");
     }
 
     @Test
@@ -255,10 +259,10 @@ class GatheringReportQueryServiceTest {
         GatheringReport report = GatheringReport.builder()
                 .gatheringId(gatheringId)
                 .teamOverallRate(new BigDecimal("80.00"))
-                .mvpUserId(100L)
-                .longestStreakUserId(100L)
-                .mostImprovedUserId(100L)
-                .attendanceUserId(100L)
+                .mvpUserIds(List.of(100L))
+                .longestStreakUserIds(List.of(100L))
+                .mostImprovedUserIds(List.of(100L))
+                .attendanceUserIds(List.of(100L))
                 .weeklyRates("invalid-json")
                 .build();
 

--- a/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportQueryServiceTest.java
@@ -79,6 +79,7 @@ class GatheringReportQueryServiceTest {
                 .teamOverallRate(new BigDecimal("78.50"))
                 .mvpUserIds(List.of(100L))
                 .longestStreakUserIds(List.of(100L))
+                .longestStreakValue(2)
                 .mostImprovedUserIds(List.of(200L))
                 .attendanceUserIds(List.of(100L))
                 .weeklyRates("""
@@ -261,6 +262,7 @@ class GatheringReportQueryServiceTest {
                 .teamOverallRate(new BigDecimal("80.00"))
                 .mvpUserIds(List.of(100L))
                 .longestStreakUserIds(List.of(100L))
+                .longestStreakValue(0)
                 .mostImprovedUserIds(List.of(100L))
                 .attendanceUserIds(List.of(100L))
                 .weeklyRates("invalid-json")

--- a/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportServiceTest.java
@@ -34,7 +34,9 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -103,7 +105,8 @@ class GatheringReportServiceTest {
         when(gatheringReportRepository.findByGatheringId(gatheringId)).thenReturn(Optional.empty());
         when(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId))
                 .thenReturn(List.of(leader, member));
-        when(todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId))
+        when(todoRepository.findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(
+                eq(gatheringId), anyCollection()))
                 .thenReturn(todos);
         when(objectMapper.writeValueAsString(anyList()))
                 .thenReturn("[{\"week\":1,\"rate\":50.0},{\"week\":2,\"rate\":75.0},{\"week\":3,\"rate\":75.0},{\"week\":4,\"rate\":75.0}]");
@@ -214,7 +217,8 @@ class GatheringReportServiceTest {
         when(gatheringReportRepository.findByGatheringId(gatheringId)).thenReturn(Optional.empty());
         when(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId))
                 .thenReturn(List.of(leader));
-        when(todoRepository.findByGatheringIdOrderByWeekNumberAscCreatedAtAsc(gatheringId))
+        when(todoRepository.findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(
+                eq(gatheringId), anyCollection()))
                 .thenReturn(todos);
         when(objectMapper.writeValueAsString(anyList()))
                 .thenThrow(new JsonProcessingException("serialize fail") {});

--- a/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportServiceTest.java
@@ -124,6 +124,7 @@ class GatheringReportServiceTest {
         assertThat(saved.getTeamOverallRate()).isEqualByComparingTo("56.30");
         assertThat(saved.getMvpUserIds()).containsExactly(100L);
         assertThat(saved.getLongestStreakUserIds()).containsExactly(100L);
+        assertThat(saved.getLongestStreakValue()).isEqualTo(2);
         assertThat(saved.getMostImprovedUserIds()).containsExactly(200L);
         assertThat(saved.getAttendanceUserIds()).containsExactly(100L);
         assertThat(saved.getWeeklyRates()).isEqualTo(

--- a/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportServiceTest.java
@@ -200,6 +200,86 @@ class GatheringReportServiceTest {
     }
 
     @Test
+    @DisplayName("아무도 완벽한 주차가 없으면 longestStreakUserIds가 비어야 한다")
+    void createReport_whenNoStreakExists_longestStreakIsEmpty() throws Exception {
+        // given
+        Long gatheringId = 1L;
+        Gathering gathering = completedGathering(gatheringId, 10L, "스트릭 없는 모임", 2);
+        GatheringMember leader = activeMember(gatheringId, 100L, GatheringRole.LEADER);
+        GatheringMember member = activeMember(gatheringId, 200L, GatheringRole.MEMBER);
+
+        List<Todo> todos = List.of(
+                // user 100 - week1: 50%, week2: 50%
+                todo(gatheringId, 100L, 1, true),
+                todo(gatheringId, 100L, 1, false),
+                todo(gatheringId, 100L, 2, true),
+                todo(gatheringId, 100L, 2, false),
+                // user 200 - week1: 50%, week2: 50%
+                todo(gatheringId, 200L, 1, true),
+                todo(gatheringId, 200L, 1, false),
+                todo(gatheringId, 200L, 2, true),
+                todo(gatheringId, 200L, 2, false)
+        );
+
+        when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.of(gathering));
+        when(gatheringReportRepository.findByGatheringId(gatheringId)).thenReturn(Optional.empty());
+        when(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId))
+                .thenReturn(List.of(leader, member));
+        when(todoRepository.findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(
+                eq(gatheringId), anyCollection()))
+                .thenReturn(todos);
+        when(objectMapper.writeValueAsString(anyList())).thenReturn("[]");
+
+        // when
+        gatheringReportService.createReport(gatheringId);
+
+        // then
+        ArgumentCaptor<GatheringReport> captor = ArgumentCaptor.forClass(GatheringReport.class);
+        verify(gatheringReportRepository).save(captor.capture());
+        assertThat(captor.getValue().getLongestStreakUserIds()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("모든 멤버의 달성률이 하락하면 mostImprovedUserIds가 비어야 한다")
+    void createReport_whenAllImprovementNegative_mostImprovedIsEmpty() throws Exception {
+        // given
+        Long gatheringId = 1L;
+        Gathering gathering = completedGathering(gatheringId, 10L, "하락 모임", 2);
+        GatheringMember leader = activeMember(gatheringId, 100L, GatheringRole.LEADER);
+        GatheringMember member = activeMember(gatheringId, 200L, GatheringRole.MEMBER);
+
+        List<Todo> todos = List.of(
+                // user 100 - week1: 100%, week2: 50% → improvement = -50
+                todo(gatheringId, 100L, 1, true),
+                todo(gatheringId, 100L, 1, true),
+                todo(gatheringId, 100L, 2, true),
+                todo(gatheringId, 100L, 2, false),
+                // user 200 - week1: 100%, week2: 50% → improvement = -50
+                todo(gatheringId, 200L, 1, true),
+                todo(gatheringId, 200L, 1, true),
+                todo(gatheringId, 200L, 2, true),
+                todo(gatheringId, 200L, 2, false)
+        );
+
+        when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.of(gathering));
+        when(gatheringReportRepository.findByGatheringId(gatheringId)).thenReturn(Optional.empty());
+        when(gatheringMemberRepository.findByGatheringIdAndIsActiveTrueOrderByIdAsc(gatheringId))
+                .thenReturn(List.of(leader, member));
+        when(todoRepository.findByGatheringIdAndUserIdInOrderByWeekNumberAscCreatedAtAsc(
+                eq(gatheringId), anyCollection()))
+                .thenReturn(todos);
+        when(objectMapper.writeValueAsString(anyList())).thenReturn("[]");
+
+        // when
+        gatheringReportService.createReport(gatheringId);
+
+        // then
+        ArgumentCaptor<GatheringReport> captor = ArgumentCaptor.forClass(GatheringReport.class);
+        verify(gatheringReportRepository).save(captor.capture());
+        assertThat(captor.getValue().getMostImprovedUserIds()).isEmpty();
+    }
+
+    @Test
     @DisplayName("주간 달성률 JSON 직렬화에 실패하면 예외가 발생한다")
     void createReport_fail_whenWeeklyRatesSerializationFails() throws Exception {
         // given

--- a/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/report/service/GatheringReportServiceTest.java
@@ -122,10 +122,10 @@ class GatheringReportServiceTest {
 
         assertThat(saved.getGatheringId()).isEqualTo(gatheringId);
         assertThat(saved.getTeamOverallRate()).isEqualByComparingTo("56.30");
-        assertThat(saved.getMvpUserId()).isEqualTo(100L);
-        assertThat(saved.getLongestStreakUserId()).isEqualTo(100L);
-        assertThat(saved.getMostImprovedUserId()).isEqualTo(200L);
-        assertThat(saved.getAttendanceUserId()).isEqualTo(100L);
+        assertThat(saved.getMvpUserIds()).containsExactly(100L);
+        assertThat(saved.getLongestStreakUserIds()).containsExactly(100L);
+        assertThat(saved.getMostImprovedUserIds()).containsExactly(200L);
+        assertThat(saved.getAttendanceUserIds()).containsExactly(100L);
         assertThat(saved.getWeeklyRates()).isEqualTo(
                 "[{\"week\":1,\"rate\":50.0},{\"week\":2,\"rate\":75.0},{\"week\":3,\"rate\":75.0},{\"week\":4,\"rate\":75.0}]"
         );
@@ -180,10 +180,10 @@ class GatheringReportServiceTest {
         GatheringReport existing = GatheringReport.builder()
                 .gatheringId(gatheringId)
                 .teamOverallRate(new BigDecimal("80.00"))
-                .mvpUserId(100L)
-                .longestStreakUserId(100L)
-                .mostImprovedUserId(200L)
-                .attendanceUserId(100L)
+                .mvpUserIds(List.of(100L))
+                .longestStreakUserIds(List.of(100L))
+                .mostImprovedUserIds(List.of(200L))
+                .attendanceUserIds(List.of(100L))
                 .weeklyRates("[]")
                 .build();
 


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #44 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [x] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> refactor/44/refactor-achievement-report -> dev

### 📑 변경 사항
1. 점수 처리할 때, 불필요한 데이터 모두 갖고오는 문제
- 문제 : 전체 Todo를 찾고와서 활성멤버를 필터링하는 방식으로 데이터가 많아질수록 메모리와 쿼리 비용 증가
- 해결: 갖고올 때 부터 활성멤버 필터링하고 갖고오기, 관련 테스트 수정

2. 누락된 인덱스 추가

3. 동점 정책
- 기존: 동점일 경우 userId오름차순
- 해결: 동점일 경우 공동 순위,공동 수상 정책으로 변경
- 관련 테스트 수정

4. 달성률 100%가 없는데 모두 최장 연속 달성상으로 뽑히는 문제, 모두 성적이 떨어졌는데 향상왕이 뽑히는 문제 해결

5. 달성률 계산 — 0건 처리 스타일 불일치 및 로직 중복문제
- 공통 유틸 메서드 추출 후 재사용함으로서 해결

6. 비활성 수상자일 경우 데이터 불일치 발생 가능성 존재
- 해결: `GatheringReport`엔티티에 필드 추가

### 🛠 테스트 결과
빌드테스트, 테스트 모두 통과하였습니다.