### PR TITLE
Refactor: Gathering 조회성능 최적화(over-fetch제거)

### DIFF
--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/repository/GatheringImageRepository.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/repository/GatheringImageRepository.java
@@ -1,11 +1,28 @@
 package com.fesi.deadlinemate.domain.gathering.repository;
 
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringImage;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface GatheringImageRepository extends JpaRepository<GatheringImage,Long> {
-    List<GatheringImage> findByGatheringIdOrderByDisplayOrderAsc(Long gatheringId);
+public interface GatheringImageRepository extends JpaRepository<GatheringImage, Long> {
+
+    interface ImageRow {
+        Long getGatheringId();
+        String getImageUrl();
+        Integer getDisplayOrder();
+    }
+
     void deleteByGatheringId(Long gatheringId);
-    List<GatheringImage> findByGatheringIdInOrderByGatheringIdAscDisplayOrderAsc(List<Long> gatheringIds);
+
+    @Query("SELECT gi.gatheringId AS gatheringId, gi.imageUrl AS imageUrl, gi.displayOrder AS displayOrder " +
+           "FROM GatheringImage gi WHERE gi.gatheringId = :gatheringId ORDER BY gi.displayOrder ASC")
+    List<ImageRow> findImageRowsByGatheringId(@Param("gatheringId") Long gatheringId);
+
+    @Query("SELECT gi.gatheringId AS gatheringId, gi.imageUrl AS imageUrl, gi.displayOrder AS displayOrder " +
+           "FROM GatheringImage gi WHERE gi.gatheringId IN :ids " +
+           "ORDER BY gi.gatheringId ASC, gi.displayOrder ASC")
+    List<ImageRow> findImageRowsByGatheringIdIn(@Param("ids") Collection<Long> ids);
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/repository/GatheringTagRepository.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/repository/GatheringTagRepository.java
@@ -4,9 +4,23 @@ import com.fesi.deadlinemate.domain.gathering.entity.GatheringTag;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface GatheringTagRepository extends JpaRepository<GatheringTag,Long> {
+public interface GatheringTagRepository extends JpaRepository<GatheringTag, Long> {
+
+    interface TagRow {
+        Long getGatheringId();
+        String getTag();
+    }
+
     void deleteByGatheringId(Long gatheringId);
-    List<GatheringTag> findByGatheringIdInOrderByGatheringIdAscIdAsc(Collection<Long> gatheringIds);
-    List<GatheringTag> findByGatheringIdOrderByIdAsc(Long gatheringId);
+
+    @Query("SELECT gt.tag FROM GatheringTag gt WHERE gt.gatheringId = :gatheringId ORDER BY gt.id ASC")
+    List<String> findTagsByGatheringId(@Param("gatheringId") Long gatheringId);
+
+    @Query("SELECT gt.gatheringId AS gatheringId, gt.tag AS tag " +
+           "FROM GatheringTag gt WHERE gt.gatheringId IN :ids " +
+           "ORDER BY gt.gatheringId ASC, gt.id ASC")
+    List<TagRow> findTagRowsByGatheringIdIn(@Param("ids") Collection<Long> ids);
 }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryService.java
@@ -8,7 +8,6 @@ import com.fesi.deadlinemate.domain.gathering.dto.response.GatheringListItemResp
 import com.fesi.deadlinemate.domain.gathering.dto.response.GatheringListResponse;
 import com.fesi.deadlinemate.domain.gathering.dto.response.GatheringMainResponse;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
-import com.fesi.deadlinemate.domain.gathering.entity.GatheringTag;
 import com.fesi.deadlinemate.domain.gathering.entity.WeeklyPlan;
 import com.fesi.deadlinemate.domain.gathering.entity.WeeklyPlanDetail;
 import com.fesi.deadlinemate.domain.gathering.projection.GatheringDetailRow;
@@ -121,12 +120,10 @@ public class GatheringQueryService {
 
         List<String> categories = findCategoryNamesByGatheringId(gatheringId);
 
-        List<String> tags = gatheringTagRepository.findByGatheringIdOrderByIdAsc(gatheringId).stream()
-                .map(GatheringTag::getTag)
-                .toList();
+        List<String> tags = gatheringTagRepository.findTagsByGatheringId(gatheringId);
 
         List<GatheringDetailResponse.ImageResponse> images = gatheringImageRepository
-                .findByGatheringIdOrderByDisplayOrderAsc(gatheringId).stream()
+                .findImageRowsByGatheringId(gatheringId).stream()
                 .map(image -> GatheringDetailResponse.ImageResponse.builder()
                         .url(image.getImageUrl())
                         .displayOrder(image.getDisplayOrder())
@@ -220,16 +217,16 @@ public class GatheringQueryService {
                 .toList();
 
         Map<Long, List<String>> tagsMap = gatheringTagRepository
-                .findByGatheringIdInOrderByGatheringIdAscIdAsc(gatheringIds)
+                .findTagRowsByGatheringIdIn(gatheringIds)
                 .stream()
                 .collect(Collectors.groupingBy(
-                        GatheringTag::getGatheringId,
+                        row -> row.getGatheringId(),
                         LinkedHashMap::new,
-                        Collectors.mapping(GatheringTag::getTag, Collectors.toList())
+                        Collectors.mapping(row -> row.getTag(), Collectors.toList())
                 ));
 
         Map<Long, List<String>> imageUrlsMap = gatheringImageRepository
-                .findByGatheringIdInOrderByGatheringIdAscDisplayOrderAsc(gatheringIds)
+                .findImageRowsByGatheringIdIn(gatheringIds)
                 .stream()
                 .collect(Collectors.groupingBy(
                         image -> image.getGatheringId(),

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/GatheringService.java
@@ -136,9 +136,9 @@ public class GatheringService {
         gatheringLikeRepository.deleteByGatheringId(gatheringId);
 
         List<String> imageUrls = gatheringImageRepository
-                .findByGatheringIdOrderByDisplayOrderAsc(gatheringId)
+                .findImageRowsByGatheringId(gatheringId)
                 .stream()
-                .map(GatheringImage::getImageUrl)
+                .map(image -> image.getImageUrl())
                 .toList();
         gatheringImageRepository.deleteByGatheringId(gatheringId);
         imageUrls.forEach(imageStorageService::delete);
@@ -416,8 +416,8 @@ public class GatheringService {
 
     private void replaceImages(Long gatheringId, List<String> imageUrls) {
         List<String> existingImageUrls = gatheringImageRepository
-                .findByGatheringIdOrderByDisplayOrderAsc(gatheringId).stream()
-                .map(GatheringImage::getImageUrl)
+                .findImageRowsByGatheringId(gatheringId).stream()
+                .map(image -> image.getImageUrl())
                 .toList();
 
         List<String> finalImageUrls = imageUrls == null ? List.of() : imageUrls;
@@ -482,9 +482,7 @@ public class GatheringService {
     }
 
     private List<String> findTags(Long gatheringId) {
-        return gatheringTagRepository.findByGatheringIdOrderByIdAsc(gatheringId).stream()
-                .map(GatheringTag::getTag)
-                .toList();
+        return gatheringTagRepository.findTagsByGatheringId(gatheringId);
     }
 
     private void saveWeeklyPlansFromCreate(

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryService.java
@@ -10,7 +10,6 @@ import com.fesi.deadlinemate.domain.gathering.entity.Gathering;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringRole;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringStatus;
-import com.fesi.deadlinemate.domain.gathering.entity.GatheringTag;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringMemberRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringRepository;
 import com.fesi.deadlinemate.domain.gathering.repository.GatheringTagRepository;
@@ -77,11 +76,11 @@ public class MembershipQueryService {
                 .collect(Collectors.toMap(GatheringMember::getGatheringId, m -> m));
 
         Map<Long, List<String>> tagsMap = gatheringTagRepository
-                .findByGatheringIdInOrderByGatheringIdAscIdAsc(resultGatheringIds).stream()
+                .findTagRowsByGatheringIdIn(resultGatheringIds).stream()
                 .collect(Collectors.groupingBy(
-                        GatheringTag::getGatheringId,
+                        row -> row.getGatheringId(),
                         LinkedHashMap::new,
-                        Collectors.mapping(GatheringTag::getTag, Collectors.toList())
+                        Collectors.mapping(row -> row.getTag(), Collectors.toList())
                 ));
 
         Map<Long, List<String>> categoriesMap = buildCategoriesMap(resultGatheringIds);

--- a/src/test/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/gathering/service/GatheringQueryServiceTest.java
@@ -20,7 +20,6 @@ import com.fesi.deadlinemate.domain.gathering.dto.response.GatheringMainResponse
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringMember;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringRole;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringStatus;
-import com.fesi.deadlinemate.domain.gathering.entity.GatheringTag;
 import com.fesi.deadlinemate.domain.gathering.entity.GatheringType;
 import com.fesi.deadlinemate.domain.gathering.entity.WeeklyPlan;
 import com.fesi.deadlinemate.domain.gathering.projection.GatheringDetailRow;
@@ -137,7 +136,7 @@ class GatheringQueryServiceTest {
             given(gatheringRepository.findMainLatest(5)).willReturn(List.of(row3));
 
             List<Long> allIds = List.of(1L, 2L, 3L);
-            given(gatheringTagRepository.findByGatheringIdInOrderByGatheringIdAscIdAsc(allIds))
+            given(gatheringTagRepository.findTagRowsByGatheringIdIn(allIds))
                     .willReturn(List.of());
             given(gatheringCategoryRepository.findByGatheringIdIn(allIds))
                     .willReturn(List.of());
@@ -154,7 +153,7 @@ class GatheringQueryServiceTest {
             assertThat(response.deadline()).hasSize(1);
             assertThat(response.latest()).hasSize(1);
             verify(gatheringTagRepository, times(1))
-                    .findByGatheringIdInOrderByGatheringIdAscIdAsc(allIds);
+                    .findTagRowsByGatheringIdIn(allIds);
             verify(gatheringCategoryRepository, times(1))
                     .findByGatheringIdIn(allIds);
             verify(userClient, times(1)).findByIds(anyList());
@@ -216,10 +215,8 @@ class GatheringQueryServiceTest {
             setField(cat, "id", 1L);
             given(categoryRepository.findByIdIn(List.of(1L))).willReturn(List.of(cat));
 
-            given(gatheringTagRepository.findByGatheringIdOrderByIdAsc(10L))
-                    .willReturn(List.of(GatheringTag.builder().gatheringId(10L).tag("React").build()));
-            given(gatheringImageRepository.findByGatheringIdOrderByDisplayOrderAsc(10L))
-                    .willReturn(List.of());
+            given(gatheringTagRepository.findTagsByGatheringId(10L)).willReturn(List.of("React"));
+            given(gatheringImageRepository.findImageRowsByGatheringId(10L)).willReturn(List.of());
 
             WeeklyPlan plan = WeeklyPlan.builder()
                     .gatheringId(10L).weekNumber(1).title("1주차")
@@ -282,7 +279,7 @@ class GatheringQueryServiceTest {
      * gatheringIds 리스트에 아이템이 있을 때 호출되는 tag/category/user 레포 스텁을 설정한다.
      */
     private void mockListHelperDeps(List<Long> gatheringIds, Long leaderId) {
-        given(gatheringTagRepository.findByGatheringIdInOrderByGatheringIdAscIdAsc(gatheringIds))
+        given(gatheringTagRepository.findTagRowsByGatheringIdIn(gatheringIds))
                 .willReturn(List.of());
         given(gatheringCategoryRepository.findByGatheringIdIn(gatheringIds))
                 .willReturn(List.of());

--- a/src/test/java/com/fesi/deadlinemate/domain/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/gathering/service/GatheringServiceTest.java
@@ -432,11 +432,8 @@ class GatheringServiceTest {
             Gathering gathering = inProgressGathering();
             given(gatheringRepository.findById(100L)).willReturn(Optional.of(gathering));
 
-            given(gatheringTagRepository.findByGatheringIdOrderByIdAsc(100L))
-                    .willReturn(List.of(
-                            GatheringTag.builder().gatheringId(100L).tag("React").build(),
-                            GatheringTag.builder().gatheringId(100L).tag("프론트엔드").build()
-                    ));
+            given(gatheringTagRepository.findTagsByGatheringId(100L))
+                    .willReturn(List.of("React", "프론트엔드"));
 
             WeeklyPlan existingPlan1 = WeeklyPlan.builder()
                     .gatheringId(100L)
@@ -492,7 +489,7 @@ class GatheringServiceTest {
 
             then(gatheringTagRepository).should(never()).deleteByGatheringId(anyLong());
             then(gatheringTagRepository).should(never()).saveAll(anyList());
-            then(gatheringTagRepository).should().findByGatheringIdOrderByIdAsc(100L);
+            then(gatheringTagRepository).should().findTagsByGatheringId(100L);
 
             then(weeklyPlanDetailRepository).should().deleteByWeeklyPlanIdIn(List.of(11L, 12L));
             then(weeklyPlanRepository).should().deleteByGatheringId(100L);
@@ -518,11 +515,8 @@ class GatheringServiceTest {
             // given
             Gathering gathering = inProgressGathering();
             given(gatheringRepository.findById(100L)).willReturn(Optional.of(gathering));
-            given(gatheringTagRepository.findByGatheringIdOrderByIdAsc(100L))
-                    .willReturn(List.of(
-                            GatheringTag.builder().gatheringId(100L).tag("React").build(),
-                            GatheringTag.builder().gatheringId(100L).tag("프론트엔드").build()
-                    ));
+            given(gatheringTagRepository.findTagsByGatheringId(100L))
+                    .willReturn(List.of("React", "프론트엔드"));
             mockCurrentGatheringCategory(100L, 1L);
 
             UpdateGatheringCommand command = inProgressAllowedUpdateCommand.toBuilder()
@@ -536,7 +530,7 @@ class GatheringServiceTest {
                     .isEqualTo(ErrorCode.INVALID_IN_PROGRESS_UPDATE_ITEMS);
 
             then(gatheringRepository).should().findById(100L);
-            then(gatheringTagRepository).should().findByGatheringIdOrderByIdAsc(100L);
+            then(gatheringTagRepository).should().findTagsByGatheringId(100L);
             then(gatheringTagRepository).should(never()).deleteByGatheringId(anyLong());
             then(gatheringTagRepository).should(never()).saveAll(anyList());
             then(weeklyPlanRepository).should(never()).deleteByGatheringId(anyLong());
@@ -568,7 +562,7 @@ class GatheringServiceTest {
             then(gatheringTagRepository).should(never()).saveAll(anyList());
             then(gatheringCategoryRepository).should(never()).deleteByGatheringId(anyLong());
             then(gatheringCategoryRepository).should(never()).saveAll(anyList());
-            then(gatheringTagRepository).should(never()).findByGatheringIdOrderByIdAsc(anyLong());
+            then(gatheringTagRepository).should(never()).findTagsByGatheringId(anyLong());
             then(weeklyPlanRepository).should(never()).deleteByGatheringId(anyLong());
             then(weeklyPlanRepository).should(never()).saveAll(anyList());
             then(eventPublisher).should(never()).publishEvent(any());

--- a/src/test/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryServiceTest.java
@@ -93,7 +93,7 @@ class MembershipQueryServiceTest {
                     .willReturn(new PageImpl<>(List.of(gathering)));
             given(gatheringMemberRepository.findByGatheringIdInAndUserIdAndIsActiveTrue(List.of(1L), 10L))
                     .willReturn(List.of(member));
-            given(gatheringTagRepository.findByGatheringIdInOrderByGatheringIdAscIdAsc(any(Collection.class)))
+            given(gatheringTagRepository.findTagRowsByGatheringIdIn(any(Collection.class)))
                     .willReturn(List.of());
             given(gatheringCategoryRepository.findByGatheringIdIn(List.of(1L)))
                     .willReturn(List.of(mapping));
@@ -122,7 +122,7 @@ class MembershipQueryServiceTest {
                     .willReturn(new PageImpl<>(List.of(gathering)));
             given(gatheringMemberRepository.findByGatheringIdInAndUserIdAndIsActiveTrue(List.of(1L), 10L))
                     .willReturn(List.of(member));
-            given(gatheringTagRepository.findByGatheringIdInOrderByGatheringIdAscIdAsc(any(Collection.class)))
+            given(gatheringTagRepository.findTagRowsByGatheringIdIn(any(Collection.class)))
                     .willReturn(List.of());
             given(gatheringCategoryRepository.findByGatheringIdIn(any())).willReturn(List.of());
             given(reviewRepository.findReviewedGatheringIds(any(), any())).willReturn(List.of());
@@ -144,7 +144,7 @@ class MembershipQueryServiceTest {
                     .willReturn(new PageImpl<>(List.of(gathering)));
             given(gatheringMemberRepository.findByGatheringIdInAndUserIdAndIsActiveTrue(List.of(1L), 10L))
                     .willReturn(List.of(member));
-            given(gatheringTagRepository.findByGatheringIdInOrderByGatheringIdAscIdAsc(any(Collection.class)))
+            given(gatheringTagRepository.findTagRowsByGatheringIdIn(any(Collection.class)))
                     .willReturn(List.of());
             given(gatheringCategoryRepository.findByGatheringIdIn(any())).willReturn(List.of());
             given(reviewRepository.findReviewedGatheringIds(any(), any())).willReturn(List.of());
@@ -169,7 +169,7 @@ class MembershipQueryServiceTest {
                     .willReturn(new PageImpl<>(List.of(gathering)));
             given(gatheringMemberRepository.findByGatheringIdInAndUserIdAndIsActiveTrue(List.of(1L), 10L))
                     .willReturn(List.of(member));
-            given(gatheringTagRepository.findByGatheringIdInOrderByGatheringIdAscIdAsc(any(Collection.class)))
+            given(gatheringTagRepository.findTagRowsByGatheringIdIn(any(Collection.class)))
                     .willReturn(List.of());
             given(gatheringCategoryRepository.findByGatheringIdIn(any())).willReturn(List.of());
             given(reviewRepository.findReviewedGatheringIds(10L, List.of(1L))).willReturn(List.of(1L));


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #44 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> refactor/44/refactor-achievement-report -> dev

### 📑 변경 사항
Gathering 조회 성능 최적화 (DTO/Projection 기반 조회로 over-fetch 제거)
- 기존 : 태그/이미지 조회 시 엔티티 전체를 로딩하여 실제로 사용하지 않는 컬럼(createdAt, updatedAt 등)까지 조회
- GatheringTag, GatheringImage 조회 시 엔티티 전체 로딩 대신 projection 기반 조회로 변경
- 필요한 컬럼만 SELECT 하도록 repository query 최적화
- GatheringQueryService에서 projection 결과 사용하도록 수정
- 관련 테스트 코드 mock 반환 타입 변경

### 🛠 테스트 결과
빌드, 테스트 모두 통과하였습니다.