### PR TITLE
Refactor: 내 모임 응답에 리뷰 작성한 멤버수 필드 추가

### DIFF
--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/response/MyGatheringListResponse.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/dto/response/MyGatheringListResponse.java
@@ -31,11 +31,13 @@ public record MyGatheringListResponse(
             GatheringRole myRole,
             boolean isLiked,
             boolean hasReviewed,
+            int reviewedMembersCount,
             @Nullable Integer pendingApplicationCount
     ) {
         public static MyGatheringItem of(Gathering gathering, GatheringRole myRole,
                                          List<String> categories, List<String> tags,
-                                         boolean hasReviewed, Integer pendingApplicationCount) {
+                                         boolean hasReviewed, int reviewedMembersCount,
+                                         Integer pendingApplicationCount) {
             return MyGatheringItem.builder()
                     .id(gathering.getId())
                     .type(gathering.getType().getDisplayName())
@@ -51,6 +53,7 @@ public record MyGatheringListResponse(
                     .myRole(myRole)
                     .isLiked(false)
                     .hasReviewed(hasReviewed)
+                    .reviewedMembersCount(reviewedMembersCount)
                     .pendingApplicationCount(pendingApplicationCount)
                     .build();
         }

--- a/src/main/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryService.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryService.java
@@ -27,7 +27,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -85,9 +84,13 @@ public class MembershipQueryService {
 
         Map<Long, List<String>> categoriesMap = buildCategoriesMap(resultGatheringIds);
 
-        Set<Long> reviewedGatheringIds = Set.copyOf(
-                reviewRepository.findReviewedGatheringIds(userId, resultGatheringIds)
-        );
+        Map<Long, Integer> reviewedCountMap = reviewRepository
+                .countReviewedMembersGroupByGathering(userId, resultGatheringIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ReviewRepository.ReviewCountRow::getGatheringId,
+                        row -> row.getCount().intValue()
+                ));
 
         List<Long> leaderGatheringIds = memberMap.values().stream()
                 .filter(m -> GatheringRole.LEADER == m.getRole())
@@ -110,12 +113,14 @@ public class MembershipQueryService {
                     Integer pendingCount = GatheringRole.LEADER == (member != null ? member.getRole() : null)
                             ? pendingCountMap.getOrDefault(gathering.getId(), 0)
                             : null;
+                    int reviewedCount = reviewedCountMap.getOrDefault(gathering.getId(), 0);
                     return MyGatheringListResponse.MyGatheringItem.of(
                             gathering,
                             member != null ? member.getRole() : null,
                             categories,
                             tags,
-                            reviewedGatheringIds.contains(gathering.getId()),
+                            reviewedCount > 0,
+                            reviewedCount,
                             pendingCount
                     );
                 })

--- a/src/main/java/com/fesi/deadlinemate/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/fesi/deadlinemate/domain/review/repository/ReviewRepository.java
@@ -19,8 +19,17 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r.matesTag, COUNT(r) FROM Review r WHERE r.targetUserId = :targetUserId AND r.matesTag IS NOT NULL GROUP BY r.matesTag")
     List<Object[]> countMatesTagsByTargetUserId(@Param("targetUserId") Long targetUserId);
 
-    @Query("SELECT r.gatheringId FROM Review r WHERE r.reviewerId = :reviewerId AND r.gatheringId IN :gatheringIds")
-    List<Long> findReviewedGatheringIds(@Param("reviewerId") Long reviewerId, @Param("gatheringIds") List<Long> gatheringIds);
+    @Query("SELECT r.gatheringId AS gatheringId, COUNT(r) AS count FROM Review r "
+            + "WHERE r.reviewerId = :reviewerId AND r.gatheringId IN :gatheringIds "
+            + "GROUP BY r.gatheringId")
+    List<ReviewCountRow> countReviewedMembersGroupByGathering(
+            @Param("reviewerId") Long reviewerId,
+            @Param("gatheringIds") List<Long> gatheringIds);
+
+    interface ReviewCountRow {
+        Long getGatheringId();
+        Long getCount();
+    }
 
     long countByTargetUserId(Long targetUserId);
 }

--- a/src/test/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryServiceTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/gathering/service/MembershipQueryServiceTest.java
@@ -99,7 +99,7 @@ class MembershipQueryServiceTest {
                     .willReturn(List.of(mapping));
             given(categoryRepository.findByIdIn(List.of(100L)))
                     .willReturn(List.of(category));
-            given(reviewRepository.findReviewedGatheringIds(any(), any())).willReturn(List.of());
+            given(reviewRepository.countReviewedMembersGroupByGathering(any(), any())).willReturn(List.of());
             given(gatheringApplicationRepository.countByGatheringIdInAndStatus(any(), any())).willReturn(List.of());
 
             MyGatheringListResponse response = membershipQueryService.getMyGatherings(10L, "all", "latest", 1, 12);
@@ -125,7 +125,7 @@ class MembershipQueryServiceTest {
             given(gatheringTagRepository.findTagRowsByGatheringIdIn(any(Collection.class)))
                     .willReturn(List.of());
             given(gatheringCategoryRepository.findByGatheringIdIn(any())).willReturn(List.of());
-            given(reviewRepository.findReviewedGatheringIds(any(), any())).willReturn(List.of());
+            given(reviewRepository.countReviewedMembersGroupByGathering(any(), any())).willReturn(List.of());
             given(gatheringApplicationRepository.countByGatheringIdInAndStatus(any(), any())).willReturn(List.of());
 
             MyGatheringListResponse response = membershipQueryService.getMyGatherings(10L, "all", "oldest", 1, 12);
@@ -147,7 +147,7 @@ class MembershipQueryServiceTest {
             given(gatheringTagRepository.findTagRowsByGatheringIdIn(any(Collection.class)))
                     .willReturn(List.of());
             given(gatheringCategoryRepository.findByGatheringIdIn(any())).willReturn(List.of());
-            given(reviewRepository.findReviewedGatheringIds(any(), any())).willReturn(List.of());
+            given(reviewRepository.countReviewedMembersGroupByGathering(any(), any())).willReturn(List.of());
             List<Object[]> pendingCounts = new ArrayList<>();
             pendingCounts.add(new Object[]{1L, 3L});
             given(gatheringApplicationRepository.countByGatheringIdInAndStatus(List.of(1L), ApplicationStatus.PENDING))
@@ -172,12 +172,17 @@ class MembershipQueryServiceTest {
             given(gatheringTagRepository.findTagRowsByGatheringIdIn(any(Collection.class)))
                     .willReturn(List.of());
             given(gatheringCategoryRepository.findByGatheringIdIn(any())).willReturn(List.of());
-            given(reviewRepository.findReviewedGatheringIds(10L, List.of(1L))).willReturn(List.of(1L));
+            ReviewRepository.ReviewCountRow row = new ReviewRepository.ReviewCountRow() {
+                @Override public Long getGatheringId() { return 1L; }
+                @Override public Long getCount() { return 1L; }
+            };
+            given(reviewRepository.countReviewedMembersGroupByGathering(10L, List.of(1L))).willReturn(List.of(row));
             given(gatheringApplicationRepository.countByGatheringIdInAndStatus(any(), any())).willReturn(List.of());
 
             MyGatheringListResponse response = membershipQueryService.getMyGatherings(10L, "all", "latest", 1, 12);
 
             assertThat(response.gatherings().get(0).hasReviewed()).isTrue();
+            assertThat(response.gatherings().get(0).reviewedMembersCount()).isEqualTo(1);
         }
     }
 

--- a/src/test/java/com/fesi/deadlinemate/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/fesi/deadlinemate/domain/review/repository/ReviewRepositoryTest.java
@@ -7,6 +7,7 @@ import com.fesi.deadlinemate.domain.review.entity.ReviewTag;
 import com.fesi.deadlinemate.global.config.JpaConfig;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -132,23 +133,32 @@ class ReviewRepositoryTest {
     }
 
     @Nested
-    @DisplayName("리뷰 작성 여부 배치 조회")
-    class FindReviewedGatheringIds {
+    @DisplayName("모임별 리뷰 작성 수 집계")
+    class CountReviewedMembersGroupByGathering {
 
         @Test
-        @DisplayName("리뷰를 작성한 모임 ID만 반환한다")
-        void findReviewedGatheringIds() {
+        @DisplayName("모임별 리뷰 작성 수를 반환한다")
+        void countsPerGathering() {
             // given
             reviewRepository.saveAll(List.of(
                     review(1L, 1L, 2L, List.of(ReviewTag.DILIGENT)),
-                    review(2L, 1L, 2L, List.of(ReviewTag.PUNCTUAL))
+                    review(1L, 1L, 3L, List.of(ReviewTag.PUNCTUAL)),
+                    review(2L, 1L, 2L, List.of(ReviewTag.HELPFUL))
             ));
 
             // when
-            List<Long> result = reviewRepository.findReviewedGatheringIds(1L, List.of(1L, 2L, 3L));
+            List<ReviewRepository.ReviewCountRow> result =
+                    reviewRepository.countReviewedMembersGroupByGathering(1L, List.of(1L, 2L, 3L));
 
             // then
-            assertThat(result).containsExactlyInAnyOrder(1L, 2L);
+            Map<Long, Long> countMap = result.stream()
+                    .collect(Collectors.toMap(
+                            ReviewRepository.ReviewCountRow::getGatheringId,
+                            ReviewRepository.ReviewCountRow::getCount
+                    ));
+            assertThat(countMap).containsEntry(1L, 2L);
+            assertThat(countMap).containsEntry(2L, 1L);
+            assertThat(countMap).doesNotContainKey(3L);
         }
 
         @Test
@@ -158,7 +168,8 @@ class ReviewRepositoryTest {
             reviewRepository.save(review(1L, 1L, 2L, List.of(ReviewTag.DILIGENT)));
 
             // when
-            List<Long> result = reviewRepository.findReviewedGatheringIds(1L, List.of(2L, 3L));
+            List<ReviewRepository.ReviewCountRow> result =
+                    reviewRepository.countReviewedMembersGroupByGathering(1L, List.of(2L, 3L));
 
             // then
             assertThat(result).isEmpty();


### PR DESCRIPTION
### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> refactor/44/refactor-achievement-report->dev

### 📑 변경 사항
- 요구사항  : 마이페이지 나의 모임 카드에서 리뷰 쓰기 버튼에 (현재 유저가 리뷰한 수 / 전체 멤버 수) 표시 추가
- 현재 상황 : `GET /v1/users/me/gatherings `응답에는 `hasReviewed: boolean`만 있어 리뷰한 멤버 수를 알 수 없는 상태
- 해결 : 응답의 각 모임 항목에 reviewedMembersCount: int 필드 추가

### 🛠 테스트 결과
빌드, 테스트 모두 통과함을 확인하였습니다.